### PR TITLE
Add a useIsNodeSelected hook

### DIFF
--- a/.yarn/versions/2a4c46d5.yml
+++ b/.yarn/versions/2a4c46d5.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": minor

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ yarn add @handlewithcare/react-prosemirror prosemirror-view@1.37.1 prosemirror-s
   - [`NodeViewComponentProps`](#nodeviewcomponentprops)
   - [`useStopEvent`](#usestopevent)
   - [`useSelectNode`](#useselectnode)
+  - [`useIsNodeSelected`](#useisnodeselected)
   - [`widget`](#widget)
 - [Looking for someone to collaborate with?](#looking-for-someone-to-collaborate-with)
 
@@ -694,6 +695,16 @@ This hook can be used within a node view component to register
 [selectNode and deselectNode handlers](https://prosemirror.net/docs/ref/#view.NodeView.selectNode).
 The selectNode handler will only be called when a NodeSelection is created whose
 node is this one.
+
+### `useIsNodeSelected`
+
+```tsx
+type useIsNodeSelected = (): boolean
+```
+
+This hook can be used within a node view component to subscribe to a boolean
+value determining whether this node is selected. The hook will return true when
+a NodeSelection is created whose node is this one.
 
 ### `widget`
 

--- a/src/hooks/useIsNodeSelected.ts
+++ b/src/hooks/useIsNodeSelected.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+import { useSelectNode } from "./useSelectNode.js";
+
+export function useIsNodeSelected() {
+  const [isSelected, setIsSelected] = useState(false);
+
+  useSelectNode(
+    () => {
+      setIsSelected(true);
+    },
+    () => {
+      setIsSelected(false);
+    }
+  );
+
+  return isSelected;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { useEditorEventListener } from "./hooks/useEditorEventListener.js";
 export { useEditorState } from "./hooks/useEditorState.js";
 export { useStopEvent } from "./hooks/useStopEvent.js";
 export { useSelectNode } from "./hooks/useSelectNode.js";
+export { useIsNodeSelected } from "./hooks/useIsNodeSelected.js";
 export { reactKeys } from "./plugins/reactKeys.js";
 export { widget } from "./decorations/ReactWidgetType.js";
 


### PR DESCRIPTION
Adds a convenience hook for the most common use case of `useSelectNode`, which is just getting a boolean value describing whether the node is currently selected or not (to use for conditionally setting a class name, for example).