### PR TITLE
Configure vite to target esnext

### DIFF
--- a/.yarn/versions/4dc8fc98.yml
+++ b/.yarn/versions/4dc8fc98.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/OutputSpec.tsx
+++ b/src/components/OutputSpec.tsx
@@ -25,7 +25,7 @@ const ForwardedOutputSpec = memo(
 
     if (!Array.isArray(outputSpec)) {
       throw new Error(
-        "@nytimes/react-prosemirror only supports strings and arrays in toDOM"
+        "@handlewithcare/react-prosemirror only supports strings and arrays in toDOM"
       );
     }
 

--- a/src/plugins/componentEventListeners.ts
+++ b/src/plugins/componentEventListeners.ts
@@ -31,7 +31,9 @@ export function componentEventListeners(
   }
 
   const plugin = new Plugin({
-    key: new PluginKey("@nytimes/react-prosemirror/componentEventListeners"),
+    key: new PluginKey(
+      "@handlewithcare/react-prosemirror/componentEventListeners"
+    ),
     props: {
       handleDOMEvents: domEventHandlers,
     },

--- a/src/plugins/reactKeys.ts
+++ b/src/plugins/reactKeys.ts
@@ -10,7 +10,7 @@ export const reactKeysPluginKey = new PluginKey<{
   posToKey: Map<number, string>;
   keyToPos: Map<string, number>;
   posToNode: Map<number, Node>;
-}>("@nytimes/react-prosemirror/reactKeys");
+}>("@handlewithcare/react-prosemirror/reactKeys");
 
 /**
  * Tracks a unique key for each (non-text) node in the

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,7 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    target: "esnext",
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4673,17 +4673,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001450
-  resolution: "caniuse-lite@npm:1.0.30001450"
-  checksum: 10/0edfa19abf651a0eae0e5848480ff2fe7bf4fa2bb61573b78a15584ce6fa083928b418d671accbf607b25e14b00a11c850baef7069873148550435f47e4c22a5
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001660
-  resolution: "caniuse-lite@npm:1.0.30001660"
-  checksum: 10/5d83f0b7e2075b7e31f114f739155dc6c21b0afe8cb61180f625a4903b0ccd3d7591a5f81c930f14efddfa57040203ba0890850b8a3738f6c7f17c7dd83b9de8
+"caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001646":
+  version: 1.0.30001696
+  resolution: "caniuse-lite@npm:1.0.30001696"
+  checksum: 10/7230d3258e73daf769d1dcc46546282343970218b357b097a868176306d0ce1dd45f57d3a9ea09817dca0fc70effd3408bf4555d33238c14bb4b54b8e88d213c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Also fixes some instances of @nytimes/react-prosemirror to @handlewithcare/react-prosemirror