### PR TITLE
Add useClientLayoutEffect to quiet warnings during SSR

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     "react-hooks/exhaustive-deps": [
       "warn",
       {
-        "additionalHooks": "(useEditorEffect|useLayoutGroupEffect$)"
+        "additionalHooks": "(useEditorEffect|useLayoutGroupEffect|useClientLayoutEffect$)"
       }
     ],
     "import/extensions": ["error", "ignorePackages"],

--- a/.yarn/versions/995d0251.yml
+++ b/.yarn/versions/995d0251.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/CustomNodeView.tsx
+++ b/src/components/CustomNodeView.tsx
@@ -11,7 +11,6 @@ import React, {
   createElement,
   memo,
   useContext,
-  useLayoutEffect,
   useMemo,
   useRef,
 } from "react";
@@ -19,6 +18,7 @@ import { createPortal } from "react-dom";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
 import { EditorContext } from "../contexts/EditorContext.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { useClientOnly } from "../hooks/useClientOnly.js";
 import { useNodeViewDescriptor } from "../hooks/useNodeViewDescriptor.js";
 
@@ -55,7 +55,7 @@ export const CustomNodeView = memo(function CustomNodeView({
 
   const shouldRender = useClientOnly();
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (
       !customNodeViewRef.current ||
       !customNodeViewRootRef.current ||
@@ -71,7 +71,7 @@ export const CustomNodeView = memo(function CustomNodeView({
     };
   }, [customNodeViewRef, customNodeViewRootRef, nodeDomRef, shouldRender]);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (!customNodeView || !customNodeViewRef.current || !shouldRender) return;
 
     const { destroy, update } = customNodeViewRef.current;

--- a/src/components/LayoutGroup.tsx
+++ b/src/components/LayoutGroup.tsx
@@ -1,8 +1,9 @@
 /* Copyright (c) The New York Times Company */
-import React, { useCallback, useLayoutEffect, useRef } from "react";
+import React, { useCallback, useRef } from "react";
 import type { EffectCallback } from "react";
 
 import { LayoutGroupContext } from "../contexts/LayoutGroupContext.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { useForceUpdate } from "../hooks/useForceUpdate.js";
 
 export interface LayoutGroupProps {
@@ -31,7 +32,7 @@ export function LayoutGroup({ children }: LayoutGroupProps) {
     }
   }, [forceUpdate]);
 
-  const register = useCallback<typeof useLayoutEffect>(
+  const register = useCallback<typeof useClientLayoutEffect>(
     (effect: EffectCallback) => {
       let destroy: ReturnType<EffectCallback>;
       const create = () => {
@@ -56,7 +57,7 @@ export function LayoutGroup({ children }: LayoutGroupProps) {
     [createQueue, destroyQueue, ensureFlush]
   );
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     isUpdatePending.current = false;
     createQueue.forEach((create) => create());
     createQueue.clear();
@@ -66,7 +67,7 @@ export function LayoutGroup({ children }: LayoutGroupProps) {
     };
   });
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     isMounted.current = true;
     return () => {
       isMounted.current = false;

--- a/src/components/MarkView.tsx
+++ b/src/components/MarkView.tsx
@@ -6,12 +6,12 @@ import React, {
   memo,
   useContext,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
 } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { MarkViewDesc, ViewDesc, sortViewDescs } from "../viewdesc.js";
 
 import { OutputSpec } from "./OutputSpec.js";
@@ -45,7 +45,7 @@ export const MarkView = memo(
     if (!outputSpec)
       throw new Error(`Mark spec for ${mark.type.name} is missing toDOM`);
 
-    useLayoutEffect(() => {
+    useClientLayoutEffect(() => {
       const siblings = siblingsRef.current;
       return () => {
         if (!viewDescRef.current) return;
@@ -56,7 +56,7 @@ export const MarkView = memo(
       };
     }, [siblingsRef]);
 
-    useLayoutEffect(() => {
+    useClientLayoutEffect(() => {
       if (!domRef.current) return;
 
       const firstChildDesc = childDescriptors.current[0];

--- a/src/components/NativeWidgetView.tsx
+++ b/src/components/NativeWidgetView.tsx
@@ -1,12 +1,8 @@
 import { Decoration, EditorView } from "prosemirror-view";
-import React, {
-  MutableRefObject,
-  useContext,
-  useLayoutEffect,
-  useRef,
-} from "react";
+import React, { MutableRefObject, useContext, useRef } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { useEditorEffect } from "../hooks/useEditorEffect.js";
 import { WidgetViewDesc, sortViewDescs } from "../viewdesc.js";
 
@@ -21,7 +17,7 @@ export function NativeWidgetView({ widget, getPos }: Props) {
 
   const rootDomRef = useRef<HTMLDivElement | null>(null);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     const siblings = siblingsRef.current;
     return () => {
       if (!viewDescRef.current) return;
@@ -56,7 +52,7 @@ export function NativeWidgetView({ widget, getPos }: Props) {
     rootDomRef.current.replaceChildren(dom);
   });
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (!rootDomRef.current) return;
 
     if (!viewDescRef.current) {

--- a/src/components/SeparatorHackView.tsx
+++ b/src/components/SeparatorHackView.tsx
@@ -1,13 +1,8 @@
-import React, {
-  MutableRefObject,
-  useContext,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { MutableRefObject, useContext, useRef, useState } from "react";
 
 import { browser } from "../browser.js";
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { TrailingHackViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
@@ -20,7 +15,7 @@ export function SeparatorHackView({ getPos }: Props) {
   const ref = useRef<HTMLImageElement | null>(null);
   const [shouldRender, setShouldRender] = useState(false);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     const siblings = siblingsRef.current;
     return () => {
       if (!viewDescRef.current) return;
@@ -34,7 +29,7 @@ export function SeparatorHackView({ getPos }: Props) {
   // There's no risk of an infinite loop here, because
   // we call setShouldRender conditionally
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     const lastSibling = siblingsRef.current[siblingsRef.current.length - 1];
     if (
       (browser.safari || browser.chrome) &&

--- a/src/components/TrailingHackView.tsx
+++ b/src/components/TrailingHackView.tsx
@@ -1,11 +1,7 @@
-import React, {
-  MutableRefObject,
-  useContext,
-  useLayoutEffect,
-  useRef,
-} from "react";
+import React, { MutableRefObject, useContext, useRef } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { TrailingHackViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
@@ -18,7 +14,7 @@ export function TrailingHackView({ getPos }: Props) {
 
   const ref = useRef<(HTMLBRElement & HTMLImageElement) | null>(null);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     const siblings = siblingsRef.current;
     return () => {
       if (!viewDescRef.current) return;
@@ -29,7 +25,7 @@ export function TrailingHackView({ getPos }: Props) {
     };
   }, [siblingsRef]);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (!ref.current) return;
 
     if (!viewDescRef.current) {

--- a/src/components/WidgetView.tsx
+++ b/src/components/WidgetView.tsx
@@ -1,12 +1,8 @@
-import React, {
-  MutableRefObject,
-  useContext,
-  useLayoutEffect,
-  useRef,
-} from "react";
+import React, { MutableRefObject, useContext, useRef } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
 import { ReactWidgetDecoration } from "../decorations/ReactWidgetType.js";
+import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { WidgetViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
@@ -21,7 +17,7 @@ export function WidgetView({ widget, getPos }: Props) {
 
   const domRef = useRef<HTMLElement | null>(null);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     const siblings = siblingsRef.current;
     return () => {
       if (!viewDescRef.current) return;
@@ -32,7 +28,7 @@ export function WidgetView({ widget, getPos }: Props) {
     };
   }, [siblingsRef]);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (!domRef.current) return;
 
     if (!viewDescRef.current) {

--- a/src/hooks/useClientLayoutEffect.ts
+++ b/src/hooks/useClientLayoutEffect.ts
@@ -1,0 +1,10 @@
+import { useLayoutEffect } from "react";
+
+export function useClientLayoutEffect(
+  ...args: Parameters<typeof useLayoutEffect>
+) {
+  if (typeof document === "undefined") return;
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks, react-hooks/exhaustive-deps
+  useLayoutEffect(...args);
+}

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -9,7 +9,7 @@ import {
   MarkViewConstructor,
   NodeViewConstructor,
 } from "prosemirror-view";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
 import { beforeInputPlugin } from "../plugins/beforeInputPlugin.js";
@@ -17,6 +17,7 @@ import { SelectionDOMObserver } from "../selection/SelectionDOMObserver.js";
 import { setSsrStubs } from "../ssr.js";
 import { NodeViewDesc } from "../viewdesc.js";
 
+import { useClientLayoutEffect } from "./useClientLayoutEffect.js";
 import { useComponentEventListeners } from "./useComponentEventListeners.js";
 import { useForceUpdate } from "./useForceUpdate.js";
 
@@ -332,7 +333,7 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
     () => new ReactEditorView(null, directEditorProps)
   );
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     return () => {
       view?.destroy();
     };
@@ -342,7 +343,7 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
   // call to setView. These calls are deliberately conditional,
   // so this is not a concern.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (!mount) {
       setView(null);
       return;

--- a/src/hooks/useLayoutGroupEffect.ts
+++ b/src/hooks/useLayoutGroupEffect.ts
@@ -1,8 +1,10 @@
 /* Copyright (c) The New York Times Company */
-import { useContext, useLayoutEffect } from "react";
+import { useContext } from "react";
 import type { DependencyList, EffectCallback } from "react";
 
 import { LayoutGroupContext } from "../contexts/LayoutGroupContext.js";
+
+import { useClientLayoutEffect } from "./useClientLayoutEffect.js";
 
 /** Registers a layout effect to run at the nearest `LayoutGroup` boundary. */
 export function useLayoutGroupEffect(
@@ -13,5 +15,5 @@ export function useLayoutGroupEffect(
   // The rule for hooks wants to statically verify the deps,
   // but the dependencies are up to the caller, not this implementation.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(() => register(effect), deps);
+  useClientLayoutEffect(() => register(effect), deps);
 }

--- a/src/hooks/useNodeViewDescriptor.ts
+++ b/src/hooks/useNodeViewDescriptor.ts
@@ -4,7 +4,6 @@ import {
   MutableRefObject,
   useCallback,
   useContext,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -17,6 +16,8 @@ import {
   ViewDesc,
   sortViewDescs,
 } from "../viewdesc.js";
+
+import { useClientLayoutEffect } from "./useClientLayoutEffect.js";
 
 export function useNodeViewDescriptor(
   node: Node | undefined,
@@ -65,7 +66,7 @@ export function useNodeViewDescriptor(
   const { siblingsRef, parentRef } = useContext(ChildDescriptorsContext);
   const childDescriptors = useRef<ViewDesc[]>([]);
 
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     const siblings = siblingsRef.current;
     return () => {
       if (!nodeViewDescRef.current) return;
@@ -77,7 +78,7 @@ export function useNodeViewDescriptor(
   }, [siblingsRef]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(() => {
+  useClientLayoutEffect(() => {
     if (!node || !nodeDomRef.current) return;
 
     const firstChildDesc = childDescriptors.current[0];


### PR DESCRIPTION
This is essentially `useIsomorphicLayoutEffect`. It's unclear to me why that library uses a useEffect on the server, since useEffects _also_ do not run on the server.