### PR TITLE
Prevent running editor effects with a destroyed view during strict mode and suspense

### DIFF
--- a/.yarn/versions/e1488bb0.yml
+++ b/.yarn/versions/e1488bb0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/__tests__/useEditorViewLayoutEffect.test.tsx
+++ b/src/hooks/__tests__/useEditorViewLayoutEffect.test.tsx
@@ -25,7 +25,7 @@ function TestComponent({
 describe("useEditorViewLayoutEffect", () => {
   it("should run the effect", () => {
     const effect = jest.fn();
-    const editorView = {} as EditorView;
+    const editorView = { docView: {} } as unknown as EditorView;
     const editorState = {} as EditorState;
     const registerEventListener = () => {};
     const unregisterEventListener = () => {};
@@ -54,7 +54,7 @@ describe("useEditorViewLayoutEffect", () => {
 
   it("should not re-run the effect if no dependencies change", () => {
     const effect = jest.fn();
-    const editorView = {} as EditorView;
+    const editorView = { docView: {} } as unknown as EditorView;
     const editorState = {} as EditorState;
     const registerEventListener = () => {};
     const unregisterEventListener = () => {};
@@ -91,7 +91,7 @@ describe("useEditorViewLayoutEffect", () => {
 
   it("should re-run the effect if dependencies change", () => {
     const effect = jest.fn();
-    const editorView = {} as EditorView;
+    const editorView = { docView: {} } as unknown as EditorView;
     const editorState = {} as EditorState;
     const registerEventListener = () => {};
     const unregisterEventListener = () => {};

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -36,7 +36,8 @@ export function useEditorEffect(
   // be defined inline and run on every re-render.
   useLayoutGroupEffect(
     () => {
-      if (view) {
+      // @ts-expect-error We're making use of knowledge of internal attributes here
+      if (view?.docView) {
         flushSyncRef.current = false;
         const result = effect(view);
         flushSyncRef.current = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11793,7 +11793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-view@npm:1.37.1, prosemirror-view@npm:^1.0.0, prosemirror-view@npm:^1.13.3, prosemirror-view@npm:^1.27.0":
+"prosemirror-view@npm:1.37.1, prosemirror-view@npm:^1.0.0, prosemirror-view@npm:^1.13.3, prosemirror-view@npm:^1.27.0, prosemirror-view@npm:^1.31.0":
   version: 1.37.1
   resolution: "prosemirror-view@npm:1.37.1"
   dependencies:
@@ -11801,17 +11801,6 @@ __metadata:
     prosemirror-state: "npm:^1.0.0"
     prosemirror-transform: "npm:^1.1.0"
   checksum: 10/410aa4b75895fffe85bd547920b38d51ea00feefd0f61f52278c3a2c84cb16e3d3f9bdf7076a23d643d3f53e2a36c8ee72e520140e15f7d8fe546358a389a580
-  languageName: node
-  linkType: hard
-
-"prosemirror-view@npm:^1.31.0":
-  version: 1.37.2
-  resolution: "prosemirror-view@npm:1.37.2"
-  dependencies:
-    prosemirror-model: "npm:^1.20.0"
-    prosemirror-state: "npm:^1.0.0"
-    prosemirror-transform: "npm:^1.1.0"
-  checksum: 10/a6073928a7bd75eb4bd31389b52f7f99fe58140927623856105da542b6923583619d23e99856b7a8b1ee27f2877624d0d0251d1407ce6c72473b7854c1385172
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes nytimes/react-prosemirror#101, #8 

During Suspense, it's possible for the layout effect cleanup function that calls `view.destroy()` to be run immediately before the layout group effect that executes `useEditorEffect` callbacks. This results in calling those callbacks with a destroyed editor (one without a docView), which crashes the editor. This can be simulated in Strict Mode with the sample code from #8.

To fix this, we avoid calling useEditorEffect callbacks if the view that we have access to is destroyed. The next render will produce a new, undestroyed EditorView and trigger another callback call, so this doesn't result in any missed calls!