### PR TITLE
Hole free marks

### DIFF
--- a/.yarn/versions/492befb0.yml
+++ b/.yarn/versions/492befb0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/MarkView.tsx
+++ b/src/components/MarkView.tsx
@@ -103,7 +103,7 @@ export const MarkView = memo(
     );
 
     return (
-      <OutputSpec ref={domRef} outputSpec={outputSpec}>
+      <OutputSpec ref={domRef} outputSpec={outputSpec} isMark>
         <ChildDescriptorsContext.Provider value={childContextValue}>
           {children}
         </ChildDescriptorsContext.Provider>

--- a/src/components/OutputSpec.tsx
+++ b/src/components/OutputSpec.tsx
@@ -9,14 +9,47 @@ import React, {
 
 import { htmlAttrsToReactProps, mergeReactProps } from "../props.js";
 
+/**
+ * Whether an output spec contains a hole
+ */
+function hasHole(outputSpec: DOMOutputSpec) {
+  if (!Array.isArray(outputSpec)) {
+    throw new Error(
+      "@handlewithcare/react-prosemirror only supports strings and arrays in toDOM"
+    );
+  }
+
+  const attrs = outputSpec[1];
+
+  let start = 1;
+  if (
+    attrs &&
+    typeof attrs === "object" &&
+    attrs.nodeType == null &&
+    !Array.isArray(attrs)
+  ) {
+    start = 2;
+  }
+
+  for (let i = start; i < outputSpec.length; i++) {
+    const child = outputSpec[i] as DOMOutputSpec | 0;
+    if (child === 0) {
+      return true;
+    }
+    if (hasHole(child)) return true;
+  }
+  return false;
+}
+
 type Props = HTMLProps<HTMLElement> & {
   outputSpec: DOMOutputSpec;
+  isMark?: boolean;
   children?: ReactNode;
 };
 
 const ForwardedOutputSpec = memo(
   forwardRef<HTMLElement, Props>(function OutputSpec(
-    { outputSpec, children, ...propOverrides }: Props,
+    { outputSpec, isMark, children, ...propOverrides }: Props,
     ref
   ) {
     if (typeof outputSpec === "string") {
@@ -62,6 +95,13 @@ const ForwardedOutputSpec = memo(
       content.push(
         <ForwardedOutputSpec outputSpec={child}>{children}</ForwardedOutputSpec>
       );
+    }
+
+    // https://prosemirror.net/docs/ref/#model.MarkSpec.toDOM
+    // When the resulting spec contains a hole, that is where the
+    // marked content is placed. Otherwise, it is appended to the top node.
+    if (isMark && !hasHole(outputSpec)) {
+      content.push(createElement(tagName, props, children));
     }
     return createElement(tagName, props, ...content);
   })

--- a/src/components/__tests__/ProseMirror.draw.test.tsx
+++ b/src/components/__tests__/ProseMirror.draw.test.tsx
@@ -260,7 +260,7 @@ describe("EditorView draw", () => {
     expect(strongDom?.childNodes.item(1).textContent).toBe(" two");
   });
 
-  it("correctly wraps blokc nodes with marks", async () => {
+  it("correctly wraps block nodes with marks", async () => {
     const testSchema = new Schema<"doc" | "image", "difficulty">({
       nodes: schema.spec.nodes.update("image", {
         ...schema.spec.nodes.get("image")!,
@@ -288,5 +288,24 @@ describe("EditorView draw", () => {
     expect(difficultyDom.tagName).toBe("DIV");
     expect(difficultyDom.dataset["difficulty"]).toBe("beginner");
     expect(imageDom.tagName).toBe("IMG");
+  });
+
+  it("supports omitting the hole in mark specs", async () => {
+    const testSchema = new Schema<"doc" | "paragraph", "bold">({
+      nodes: schema.spec.nodes,
+      marks: schema.spec.marks.addToEnd("bold", {
+        toDOM() {
+          return ["strong"];
+        },
+      }),
+    });
+
+    const { doc, paragraph, bold } = builders(testSchema);
+
+    const { view } = tempEditor({
+      doc: doc(paragraph(bold("Some bold text"))),
+    });
+
+    expect(view.dom.textContent).toBe("Some bold text");
   });
 });


### PR DESCRIPTION
ProseMirror doesn't actually require holes in mark output specs!

> https://prosemirror.net/docs/ref/#model.MarkSpec.toDOM
>
> When the resulting spec contains a hole, that is where the marked content is placed. Otherwise, it is appended to the top node.

This updates the OutputSpec component so that it automatically inserts the hole for marks at the top level, matching the prosemirror-view implementation