### PR TITLE
Switch to css-tree for parsing CSS 

### DIFF
--- a/.yarn/versions/09801a45.yml
+++ b/.yarn/versions/09801a45.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/demo/schema.ts
+++ b/demo/schema.ts
@@ -88,7 +88,14 @@ export const schema = new Schema({
     },
     code: {
       toDOM() {
-        return ["code", 0];
+        return [
+          "code",
+          {
+            style:
+              "background-color: lightgray; padding: 0.125rem 0.25rem; border-radius: 2px;",
+          },
+          0,
+        ];
       },
       parseDOM: [
         {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.4.3",
+    "@types/css-tree": "^2.3.10",
     "@types/jest": "^27.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
@@ -121,6 +122,7 @@
   },
   "dependencies": {
     "classnames": "^2.3.2",
+    "css-tree": "^3.1.0",
     "react-reconciler": "0.31.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:^16.0.1"
     "@testing-library/user-event": "npm:^14.4.3"
+    "@types/css-tree": "npm:^2.3.10"
     "@types/jest": "npm:^27.0.0"
     "@types/react": "npm:^18.0.0"
     "@types/react-dom": "npm:^18.0.0"
@@ -1256,6 +1257,7 @@ __metadata:
     "@yarnpkg/sdks": "npm:^3.0.0-rc.38"
     classnames: "npm:^2.3.2"
     concurrently: "npm:^7.6.0"
+    css-tree: "npm:^3.1.0"
     eslint: "npm:^8.33.0"
     eslint-config-prettier: "npm:^8.6.0"
     eslint-import-resolver-typescript: "npm:^3.5.3"
@@ -2870,6 +2872,13 @@ __metadata:
     "@types/node": "npm:*"
     "@types/responselike": "npm:^1.0.0"
   checksum: 10/159f9fdb2a1b7175eef453ae2ced5ea04c0d2b9610cc9ccd9f9abb066d36dacb1f37acd879ace10ad7cbb649490723feb396fb7307004c9670be29636304b988
+  languageName: node
+  linkType: hard
+
+"@types/css-tree@npm:^2.3.10":
+  version: 2.3.10
+  resolution: "@types/css-tree@npm:2.3.10"
+  checksum: 10/d4c8d36eb6fc5ed97fadd64bb501e7cc0d87a40567ed915e2d9797402e8c278fe4f9cd62c97beb9a629682d8c8ed66862ef44dc02c3ad20566d1374c086bc9cd
   languageName: node
   linkType: hard
 
@@ -5257,6 +5266,16 @@ __metadata:
   version: 1.1.1
   resolution: "css-shorthand-properties@npm:1.1.1"
   checksum: 10/f8de209800a3a577a531dc155a6ff6d86fc2688c70c5c4f9fa20073531bab49caa80435d14f7ef7d130d104527c76bd4b2c03d768d4ff56c585727f3c280e24b
+  languageName: node
+  linkType: hard
+
+"css-tree@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "css-tree@npm:3.1.0"
+  dependencies:
+    mdn-data: "npm:2.12.2"
+    source-map-js: "npm:^1.0.1"
+  checksum: 10/e8c5c8e98e3aa4a620fda0b813ce57ccf99281652bf9d23e5cdfc9961c9a93a6769941f9a92e31e65d90f446f42fa83879ab0185206dc7a178d9f656d0913e14
   languageName: node
   linkType: hard
 
@@ -10165,6 +10184,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdn-data@npm:2.12.2":
+  version: 2.12.2
+  resolution: "mdn-data@npm:2.12.2"
+  checksum: 10/854e41715a9358e69f9a530117cd6ca7e71d06176469de8d70b1e629753b6827f5bd730995c16ad3750f3c9bad92230f8e4e178de2b34926b05f5205d27d76af
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -12833,7 +12859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3


### PR DESCRIPTION
Previously, we used the browser's built in CSSStyleSheet
to parse CSS and transform it into React-compatible style
props. This is unavailable in SSR contexts, so we switch
to a pure-JavaScript library, css-tree, which supports
parsing CSS in the browser and on the server.