### PR TITLE
Custom node view improvements

### DIFF
--- a/.yarn/versions/e4bd3158.yml
+++ b/.yarn/versions/e4bd3158.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": minor

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ yarn add @handlewithcare/react-prosemirror prosemirror-view@1.37.1 prosemirror-s
   - [`useEditorEffect`](#useeditoreffect-1)
   - [`NodeViewComponentProps`](#nodeviewcomponentprops)
   - [`useStopEvent`](#usestopevent)
+  - [`useIgnoreMutation`](#useignoremutation)
   - [`useSelectNode`](#useselectnode)
   - [`useIsNodeSelected`](#useisnodeselected)
   - [`widget`](#widget)
@@ -684,6 +685,16 @@ type useStopEvent = (stopEvent: (view: EditorView, event: Event) => boolean): vo
 This hook can be used within a node view component to register a
 [stopEvent handler](https://prosemirror.net/docs/ref/#view.NodeView.stopEvent).
 Events for which this returns true are not handled by the editor.
+
+### `useIgnoreMutation`
+
+```tsx
+type useIgnoreMutation = (stopEvent: (view: EditorView, mutation: ViewMutationRecord) => boolean): void
+```
+
+This hook can be used within a node view component to register an
+[ignoreMutation handler](https://prosemirror.net/docs/ref/#view.NodeView.ignoreMutation).
+Mutations for which this returns true are not handled by the editor.
 
 ### `useSelectNode`
 

--- a/src/components/CustomNodeView.tsx
+++ b/src/components/CustomNodeView.tsx
@@ -1,4 +1,5 @@
 import { Node } from "prosemirror-model";
+import { NodeSelection } from "prosemirror-state";
 import {
   Decoration,
   DecorationSource,
@@ -45,34 +46,89 @@ export const CustomNodeView = memo(function CustomNodeView({
   const contentDomRef = useRef<HTMLElement | null>(null);
   const getPosFunc = useRef(() => getPos.current()).current;
 
-  // this is ill-conceived; should revisit
-  const initialNode = useRef(node);
-  const initialOuterDeco = useRef(outerDeco);
-  const initialInnerDeco = useRef(innerDeco);
+  const nodeRef = useRef(node);
+  nodeRef.current = node;
+  const outerDecoRef = useRef(outerDeco);
+  outerDecoRef.current = outerDeco;
+  const innerDecoRef = useRef(innerDeco);
+  innerDecoRef.current = innerDeco;
 
   const customNodeViewRootRef = useRef<HTMLDivElement | null>(null);
   const customNodeViewRef = useRef<NodeViewT | null>(null);
 
   const shouldRender = useClientOnly();
 
+  // In Strict/Concurrent mode, layout effects can be destroyed/re-run
+  // independently of renders. We need to ensure that if the
+  // destructor that destroys the node view is called, we then recreate
+  // the node view when the layout effect is re-run.
   useClientLayoutEffect(() => {
-    if (
-      !customNodeViewRef.current ||
-      !customNodeViewRootRef.current ||
-      !shouldRender
-    )
-      return;
+    if (!customNodeViewRef.current || !shouldRender) {
+      customNodeViewRef.current = customNodeView(
+        nodeRef.current,
+        // customNodeView will only be set if view is set, and we can only reach
+        // this line if customNodeView is set
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        view!,
+        getPosFunc,
+        outerDecoRef.current,
+        innerDecoRef.current
+      );
+      if (customNodeViewRef.current.stopEvent) {
+        setStopEvent(
+          customNodeViewRef.current.stopEvent.bind(customNodeViewRef.current)
+        );
+      }
+      if (customNodeViewRef.current.selectNode) {
+        setSelectNode(
+          customNodeViewRef.current.selectNode.bind(customNodeViewRef.current),
+          customNodeViewRef.current.deselectNode?.bind(
+            customNodeViewRef.current
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+          ) ?? (() => {})
+        );
+      }
+      if (customNodeViewRef.current.ignoreMutation) {
+        setIgnoreMutation(
+          customNodeViewRef.current.ignoreMutation.bind(
+            customNodeViewRef.current
+          )
+        );
+      }
 
-    const { dom } = customNodeViewRef.current;
-    nodeDomRef.current = customNodeViewRootRef.current;
-    customNodeViewRootRef.current.appendChild(dom);
+      if (!customNodeViewRootRef.current) return;
+
+      const { dom } = customNodeViewRef.current;
+      nodeDomRef.current = customNodeViewRootRef.current;
+      customNodeViewRootRef.current.appendChild(dom);
+
+      // Layout effects can run multiple times — if this effect
+      // destroyed and recreated this node view, then we need to
+      // resync the selectNode state
+      if (
+        view?.state.selection instanceof NodeSelection &&
+        view.state.selection.node === nodeRef.current
+      ) {
+        customNodeViewRef.current.selectNode?.();
+      }
+    }
+
+    const nodeView = customNodeViewRef.current;
+
     return () => {
-      customNodeViewRef.current?.destroy?.();
+      nodeView.destroy?.();
+      customNodeViewRef.current = null;
     };
-  }, [customNodeViewRef, customNodeViewRootRef, nodeDomRef, shouldRender]);
+    // setStopEvent, setSelectNodee, and setIgnoreMutation are all stable
+    // functions and don't need to be added to the dependencies. They also
+    // can't be, because they come from useNodeViewDescriptor, which
+    // _has_ to be called after this hook, so that the effects run
+    // in the correct order
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customNodeView, getPosFunc, view]);
 
   useClientLayoutEffect(() => {
-    if (!customNodeView || !customNodeViewRef.current || !shouldRender) return;
+    if (!customNodeView || !customNodeViewRef.current) return;
 
     const { destroy, update } = customNodeViewRef.current;
 
@@ -85,39 +141,20 @@ export const CustomNodeView = memo(function CustomNodeView({
 
     if (!customNodeViewRootRef.current) return;
 
-    initialNode.current = node;
-    initialOuterDeco.current = outerDeco;
-    initialInnerDeco.current = innerDeco;
-
     customNodeViewRef.current = customNodeView(
-      initialNode.current,
+      nodeRef.current,
       // customNodeView will only be set if view is set, and we can only reach
       // this line if customNodeView is set
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       view!,
       getPosFunc,
-      initialOuterDeco.current,
-      initialInnerDeco.current
+      outerDecoRef.current,
+      innerDecoRef.current
     );
     const { dom } = customNodeViewRef.current;
     nodeDomRef.current = customNodeViewRootRef.current;
     customNodeViewRootRef.current.appendChild(dom);
-  }, [
-    customNodeView,
-    view,
-    innerDeco,
-    node,
-    outerDeco,
-    getPos,
-    customNodeViewRef,
-    customNodeViewRootRef,
-    initialNode,
-    initialOuterDeco,
-    initialInnerDeco,
-    nodeDomRef,
-    shouldRender,
-    getPosFunc,
-  ]);
+  }, [customNodeView, view, innerDeco, node, outerDeco, getPos, getPosFunc]);
 
   const {
     childDescriptors,
@@ -146,16 +183,21 @@ export const CustomNodeView = memo(function CustomNodeView({
 
   if (!shouldRender) return null;
 
+  // In order to render the correct element with the correct
+  // props below, we have to call the customNodeView in the
+  // render function here. We only do this once, and the
+  // results are stored in a ref but not actually appended
+  // to the DOM until a client effect
   if (!customNodeViewRef.current) {
     customNodeViewRef.current = customNodeView(
-      initialNode.current,
+      nodeRef.current,
       // customNodeView will only be set if view is set, and we can only reach
       // this line if customNodeView is set
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       view!,
       () => getPos.current(),
-      initialOuterDeco.current,
-      initialInnerDeco.current
+      outerDecoRef.current,
+      innerDecoRef.current
     );
     if (customNodeViewRef.current.stopEvent) {
       setStopEvent(

--- a/src/components/CustomNodeView.tsx
+++ b/src/components/CustomNodeView.tsx
@@ -119,9 +119,15 @@ export const CustomNodeView = memo(function CustomNodeView({
     getPosFunc,
   ]);
 
-  const { childDescriptors, nodeViewDescRef } = useNodeViewDescriptor(
+  const {
+    childDescriptors,
+    nodeViewDescRef,
+    setStopEvent,
+    setSelectNode,
+    setIgnoreMutation,
+  } = useNodeViewDescriptor(
     node,
-    () => getPos.current(),
+    getPosFunc,
     domRef,
     nodeDomRef,
     innerDeco,
@@ -151,6 +157,25 @@ export const CustomNodeView = memo(function CustomNodeView({
       initialOuterDeco.current,
       initialInnerDeco.current
     );
+    if (customNodeViewRef.current.stopEvent) {
+      setStopEvent(
+        customNodeViewRef.current.stopEvent.bind(customNodeViewRef.current)
+      );
+    }
+    if (customNodeViewRef.current.selectNode) {
+      setSelectNode(
+        customNodeViewRef.current.selectNode.bind(customNodeViewRef.current),
+        customNodeViewRef.current.deselectNode?.bind(
+          customNodeViewRef.current
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+        ) ?? (() => {})
+      );
+    }
+    if (customNodeViewRef.current.ignoreMutation) {
+      setIgnoreMutation(
+        customNodeViewRef.current.ignoreMutation.bind(customNodeViewRef.current)
+      );
+    }
   }
   const { contentDOM } = customNodeViewRef.current;
   contentDomRef.current = contentDOM ?? null;

--- a/src/components/ReactNodeView.tsx
+++ b/src/components/ReactNodeView.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
+import { IgnoreMutationContext } from "../contexts/IgnoreMutationContext.js";
 import { NodeViewContext } from "../contexts/NodeViewContext.js";
 import { SelectNodeContext } from "../contexts/SelectNodeContext.js";
 import { StopEventContext } from "../contexts/StopEventContext.js";
@@ -60,6 +61,7 @@ export const ReactNodeView = memo(function ReactNodeView({
     childDescriptors,
     setStopEvent,
     setSelectNode,
+    setIgnoreMutation,
     nodeViewDescRef,
   } = useNodeViewDescriptor(
     node,
@@ -139,9 +141,11 @@ export const ReactNodeView = memo(function ReactNodeView({
   return (
     <SelectNodeContext.Provider value={setSelectNode}>
       <StopEventContext.Provider value={setStopEvent}>
-        <ChildDescriptorsContext.Provider value={childContextValue}>
-          {decoratedElement}
-        </ChildDescriptorsContext.Provider>
+        <IgnoreMutationContext.Provider value={setIgnoreMutation}>
+          <ChildDescriptorsContext.Provider value={childContextValue}>
+            {decoratedElement}
+          </ChildDescriptorsContext.Provider>
+        </IgnoreMutationContext.Provider>
       </StopEventContext.Provider>
     </SelectNodeContext.Provider>
   );

--- a/src/contexts/IgnoreMutationContext.ts
+++ b/src/contexts/IgnoreMutationContext.ts
@@ -1,0 +1,10 @@
+import { ViewMutationRecord } from "prosemirror-view";
+import { createContext } from "react";
+
+type IgnoreMutationtContextValue = (
+  ignoreMutation: (mutation: ViewMutationRecord) => boolean
+) => void;
+
+export const IgnoreMutationContext = createContext<IgnoreMutationtContextValue>(
+  null as unknown as IgnoreMutationtContextValue
+);

--- a/src/hooks/useClientOnly.ts
+++ b/src/hooks/useClientOnly.ts
@@ -1,9 +1,16 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function unsubscribe() {}
+
+function subscribe() {
+  return unsubscribe;
+}
 
 export function useClientOnly() {
-  const [render, setRender] = useState(false);
-  useEffect(() => {
-    setRender(true);
-  }, []);
-  return render;
+  return useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false
+  );
 }

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -314,7 +314,8 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
       },
       () => {
         /* The doc node can't have a node selection*/
-      }
+      },
+      () => false
     )
   );
 

--- a/src/hooks/useEditorEventCallback.ts
+++ b/src/hooks/useEditorEventCallback.ts
@@ -31,10 +31,12 @@ export function useEditorEventCallback<T extends unknown[], R>(
 
   return useCallback(
     (...args: T) => {
-      if (view) {
-        return ref.current(view, ...args);
-      }
-      return;
+      // It's not actually possible for an event handler to run
+      // while view is null, since view is only ever set to
+      // null in a layout effect that then immediately triggers
+      // a re-render which sets view to a new EditorView
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return ref.current(view!, ...args);
     },
     [view]
   );

--- a/src/hooks/useIgnoreMutation.ts
+++ b/src/hooks/useIgnoreMutation.ts
@@ -1,0 +1,17 @@
+import { EditorView, ViewMutationRecord } from "prosemirror-view";
+import { useContext } from "react";
+
+import { IgnoreMutationContext } from "../contexts/IgnoreMutationContext.js";
+
+import { useEditorEffect } from "./useEditorEffect.js";
+import { useEditorEventCallback } from "./useEditorEventCallback.js";
+
+export function useIgnoreMutation(
+  ignoreMutation: (view: EditorView, mutation: ViewMutationRecord) => boolean
+) {
+  const register = useContext(IgnoreMutationContext);
+  const ignoreMutationMemo = useEditorEventCallback(ignoreMutation);
+  useEditorEffect(() => {
+    register(ignoreMutationMemo);
+  }, [register, ignoreMutationMemo]);
+}

--- a/src/hooks/useNodeViewDescriptor.ts
+++ b/src/hooks/useNodeViewDescriptor.ts
@@ -1,5 +1,9 @@
 import { Node } from "prosemirror-model";
-import { Decoration, DecorationSource } from "prosemirror-view";
+import {
+  Decoration,
+  DecorationSource,
+  ViewMutationRecord,
+} from "prosemirror-view";
 import {
   MutableRefObject,
   useCallback,
@@ -36,6 +40,15 @@ export function useNodeViewDescriptor(
   const setStopEvent = useCallback(
     (newStopEvent: (event: Event) => boolean | undefined) => {
       stopEvent.current = newStopEvent;
+    },
+    []
+  );
+  const ignoreMutation = useRef<(mutation: ViewMutationRecord) => boolean>(
+    () => false
+  );
+  const setIgnoreMutation = useCallback(
+    (newIgnoreMutation: (mutation: ViewMutationRecord) => boolean) => {
+      ignoreMutation.current = newIgnoreMutation;
     },
     []
   );
@@ -96,7 +109,8 @@ export function useNodeViewDescriptor(
         nodeDomRef.current,
         (event) => !!stopEvent.current(event),
         () => selectNode.current(),
-        () => deselectNode.current()
+        () => deselectNode.current(),
+        (mutation) => ignoreMutation.current(mutation)
       );
     } else {
       nodeViewDescRef.current.parent = parentRef.current;
@@ -179,5 +193,6 @@ export function useNodeViewDescriptor(
     nodeViewDescRef,
     setStopEvent,
     setSelectNode,
+    setIgnoreMutation,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { useEditorEventListener } from "./hooks/useEditorEventListener.js";
 export { useEditorState } from "./hooks/useEditorState.js";
 export { useStopEvent } from "./hooks/useStopEvent.js";
 export { useSelectNode } from "./hooks/useSelectNode.js";
+export { useIgnoreMutation } from "./hooks/useIgnoreMutation.js";
 export { useIsNodeSelected } from "./hooks/useIsNodeSelected.js";
 export { reactKeys } from "./plugins/reactKeys.js";
 export { widget } from "./decorations/ReactWidgetType.js";

--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -808,7 +808,8 @@ export class NodeViewDesc extends ViewDesc {
     public nodeDOM: DOMNode,
     public stopEvent: (event: Event) => boolean,
     public selectNode: () => void,
-    public deselectNode: () => void
+    public deselectNode: () => void,
+    public ignoreMutation: (mutation: ViewMutationRecord) => boolean
   ) {
     super(parent, children, getPos, dom, contentDOM);
   }
@@ -915,6 +916,9 @@ export class TextViewDesc extends NodeViewDesc {
       },
       () => {
         /* Text nodes can't have node selections */
+      },
+      (mutation) => {
+        return mutation.type != "characterData" && mutation.type != "selection";
       }
     );
   }
@@ -950,10 +954,6 @@ export class TextViewDesc extends NodeViewDesc {
     if (dom == this.nodeDOM)
       return this.posAtStart + Math.min(offset, this.node.text!.length);
     return super.localPosFromDOM(dom, offset, bias);
-  }
-
-  ignoreMutation(mutation: ViewMutationRecord) {
-    return mutation.type != "characterData" && mutation.type != "selection";
   }
 
   markDirty(from: number, to: number) {


### PR DESCRIPTION
Passes through stopEvent, ignoreMutation, and selectNode hooks
to the NodeViewDesc for non-React custom node views.

Also adds a `useIgnoreMutation` React hook for React-based
custom node views to specify a custom ignoreMutation hook.

Also also, fixes the useClientOnly implementation (now uses `useSyncExternalStore` to avoid unnecessary double renders on the client with newly mounted components) and issues with Strict/Concurrent mode for custom node views.