### PR TITLE
Use ComponentType for nodeViews prop type (fro React 19)

### DIFF
--- a/.yarn/versions/e610ba97.yml
+++ b/.yarn/versions/e610ba97.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ const Paragraph = forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
     });
 
     return (
-      <p ref={ref} {...props}>
+      <p {...props} ref={ref}>
         {children}
       </p>
     );
@@ -403,7 +403,7 @@ const Paragraph = forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
     );
 
     return (
-      <p ref={ref} {...props} onClick={onClick}>
+      <p {...props} ref={ref} onClick={onClick}>
         {children}
       </p>
     );

--- a/demo/nodeViews/CodeBlock.tsx
+++ b/demo/nodeViews/CodeBlock.tsx
@@ -260,6 +260,7 @@ export const CodeBlock = forwardRef<
 
   return (
     <div
+      {...props}
       ref={(el) => {
         ref.current = el;
         if (!outerRef) {
@@ -275,7 +276,6 @@ export const CodeBlock = forwardRef<
       onClick={(e) => {
         cmViewRef.current?.focus();
       }}
-      {...props}
     >
       <ReactCodeMirror
         ref={cmElRef}

--- a/src/components/NodeViewComponentProps.tsx
+++ b/src/components/NodeViewComponentProps.tsx
@@ -1,6 +1,6 @@
 import { Node } from "prosemirror-model";
 import { Decoration, DecorationSource } from "prosemirror-view";
-import { HTMLAttributes, ReactNode } from "react";
+import { HTMLAttributes, ReactNode, Ref } from "react";
 
 export type NodeViewComponentProps = {
   nodeProps: {
@@ -10,4 +10,10 @@ export type NodeViewComponentProps = {
     children?: ReactNode | ReactNode[];
     getPos: () => number;
   };
+  // It's not really feasible to correctly type a Ref constraint,
+  // because it needs to be both covariant and contravariant (because
+  // it could be either a RefObject or a RefCallback). So we use any,
+  // here, instead of a more useful type like HTMLElement | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ref: Ref<any>;
 } & HTMLAttributes<HTMLElement>;

--- a/src/components/ProseMirror.tsx
+++ b/src/components/ProseMirror.tsx
@@ -4,7 +4,7 @@ import {
   NodeViewConstructor,
 } from "prosemirror-view";
 import React, {
-  ForwardRefExoticComponent,
+  ComponentType,
   ReactNode,
   RefAttributes,
   useMemo,
@@ -26,7 +26,7 @@ export type Props = Omit<UseEditorOptions, "nodeViews"> & {
   className?: string;
   children?: ReactNode;
   nodeViews?: {
-    [nodeType: string]: ForwardRefExoticComponent<
+    [nodeType: string]: ComponentType<
       // We need to allow refs to any type of HTMLElement, but there's
       // no way to express that that still allows consumers to correctly
       // type their own refs. This is sufficient to ensure that there's

--- a/src/components/ProseMirror.tsx
+++ b/src/components/ProseMirror.tsx
@@ -3,13 +3,7 @@ import {
   DecorationSet,
   NodeViewConstructor,
 } from "prosemirror-view";
-import React, {
-  ComponentType,
-  ReactNode,
-  RefAttributes,
-  useMemo,
-  useState,
-} from "react";
+import React, { ComponentType, ReactNode, useMemo, useState } from "react";
 
 import { EditorContext } from "../contexts/EditorContext.js";
 import { EditorStateContext } from "../contexts/EditorStateContext.js";
@@ -26,14 +20,7 @@ export type Props = Omit<UseEditorOptions, "nodeViews"> & {
   className?: string;
   children?: ReactNode;
   nodeViews?: {
-    [nodeType: string]: ComponentType<
-      // We need to allow refs to any type of HTMLElement, but there's
-      // no way to express that that still allows consumers to correctly
-      // type their own refs. This is sufficient to ensure that there's
-      // a ref of _some_ kind, which is enough.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      NodeViewComponentProps & RefAttributes<any>
-    >;
+    [nodeType: string]: ComponentType<NodeViewComponentProps>;
   };
   customNodeViews?: {
     [nodeType: string]: NodeViewConstructor;

--- a/src/components/ReactNodeView.tsx
+++ b/src/components/ReactNodeView.tsx
@@ -1,9 +1,8 @@
 import { DOMOutputSpec, Node } from "prosemirror-model";
 import { Decoration, DecorationSource } from "prosemirror-view";
 import React, {
-  ForwardRefExoticComponent,
+  ComponentType,
   MutableRefObject,
-  RefAttributes,
   cloneElement,
   memo,
   useContext,
@@ -45,11 +44,8 @@ export const ReactNodeView = memo(function ReactNodeView({
 
   let element: JSX.Element | null = null;
 
-  const Component:
-    | ForwardRefExoticComponent<
-        NodeViewComponentProps & RefAttributes<HTMLElement>
-      >
-    | undefined = nodeViews[node.type.name];
+  const Component: ComponentType<NodeViewComponentProps> | undefined =
+    nodeViews[node.type.name];
 
   const outputSpec: DOMOutputSpec | undefined = useMemo(
     () => node.type.spec.toDOM?.(node),

--- a/src/components/__tests__/ProseMirror.draw-decoration.test.tsx
+++ b/src/components/__tests__/ProseMirror.draw-decoration.test.tsx
@@ -28,7 +28,7 @@ import {
   DecorationSource,
   EditorView,
 } from "prosemirror-view";
-import React, { LegacyRef, forwardRef, useEffect } from "react";
+import React, { forwardRef, useEffect } from "react";
 
 import { widget } from "../../decorations/ReactWidgetType.js";
 import { useEditorEffect } from "../../hooks/useEditorEffect.js";
@@ -36,10 +36,10 @@ import { tempEditor } from "../../testing/editorViewTestHelpers.js";
 import { NodeViewComponentProps } from "../NodeViewComponentProps.js";
 import { WidgetViewComponentProps } from "../WidgetViewComponentProps.js";
 
-const Widget = forwardRef<HTMLElement, WidgetViewComponentProps>(
+const Widget = forwardRef<HTMLButtonElement, WidgetViewComponentProps>(
   function Widget({ widget, getPos, ...props }, ref) {
     return (
-      <button ref={ref as LegacyRef<HTMLButtonElement>} {...props}>
+      <button ref={ref} {...props}>
         ω
       </button>
     );
@@ -256,16 +256,15 @@ describe("Decoration drawing", () => {
 
   it("calls widget destroy methods", async () => {
     let destroyed = false;
-    const DestroyableWidget = forwardRef<HTMLElement, WidgetViewComponentProps>(
-      function DestroyableWidget({ widget, getPos, ...props }, ref) {
-        useEffect(() => {
-          destroyed = true;
-        });
-        return (
-          <button ref={ref as LegacyRef<HTMLButtonElement>} {...props}></button>
-        );
-      }
-    );
+    const DestroyableWidget = forwardRef<
+      HTMLButtonElement,
+      WidgetViewComponentProps
+    >(function DestroyableWidget({ widget, getPos, ...props }, ref) {
+      useEffect(() => {
+        destroyed = true;
+      });
+      return <button ref={ref} {...props}></button>;
+    });
     const { view } = tempEditor({
       doc: doc(p("abc")),
       plugins: [
@@ -564,7 +563,7 @@ describe("Decoration drawing", () => {
         horizontal_rule: forwardRef<HTMLHRElement, NodeViewComponentProps>(
           function HR({ nodeProps, children, ...props }, ref) {
             current = nodeProps.decorations.map((d) => d.spec.name).join();
-            return <hr ref={ref as LegacyRef<HTMLHRElement>} {...props} />;
+            return <hr {...props} ref={ref} />;
           }
         ),
       },
@@ -594,9 +593,7 @@ describe("Decoration drawing", () => {
               { widget, getPos, ...props },
               ref
             ) {
-              return (
-                <img {...props} ref={ref as LegacyRef<HTMLImageElement>} />
-              );
+              return <img {...props} ref={ref} />;
             }),
             {
               marks: [schema.mark("em")],
@@ -620,9 +617,7 @@ describe("Decoration drawing", () => {
               { widget, getPos, ...props },
               ref
             ) {
-              return (
-                <img {...props} ref={ref as LegacyRef<HTMLImageElement>} />
-              );
+              return <img {...props} ref={ref} />;
             }),
             { side: -1, key: "img-widget" }
           ),
@@ -630,11 +625,11 @@ describe("Decoration drawing", () => {
         decoPlugin([
           widget(
             4,
-            forwardRef<HTMLImageElement, WidgetViewComponentProps>(function BR(
+            forwardRef<HTMLBRElement, WidgetViewComponentProps>(function BR(
               { widget, getPos, ...props },
               ref
             ) {
-              return <br {...props} ref={ref as LegacyRef<HTMLBRElement>} />;
+              return <br {...props} ref={ref} />;
             }),
             { key: "br-widget" }
           ),
@@ -666,7 +661,7 @@ describe("Decoration drawing", () => {
         paragraph: forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
           function Paragraph({ nodeProps, children, ...props }, ref) {
             return (
-              <p ref={ref as LegacyRef<HTMLParagraphElement>} {...props}>
+              <p {...props} ref={ref}>
                 {children}
               </p>
             );
@@ -681,9 +676,7 @@ describe("Decoration drawing", () => {
               { widget, getPos, ...props },
               ref
             ) {
-              return (
-                <img {...props} ref={ref as LegacyRef<HTMLImageElement>} />
-              );
+              return <img {...props} ref={ref} />;
             }),
             { key: "img-widget" }
           ),
@@ -735,7 +728,7 @@ describe("Decoration drawing", () => {
               ) {
                 expect(getPos()).toBe(3);
                 return (
-                  <button ref={ref as LegacyRef<HTMLButtonElement>} {...props}>
+                  <button ref={ref} {...props}>
                     ω
                   </button>
                 );
@@ -857,7 +850,7 @@ describe("Decoration drawing", () => {
           ) {
             decosFromFirstEditor = nodeProps.innerDecorations;
             return (
-              <p ref={ref as LegacyRef<HTMLParagraphElement>} {...props}>
+              <p {...props} ref={ref}>
                 {children}
               </p>
             );

--- a/src/components/__tests__/ProseMirror.draw.test.tsx
+++ b/src/components/__tests__/ProseMirror.draw.test.tsx
@@ -188,7 +188,7 @@ describe("EditorView draw", () => {
       nodeViews: {
         horizontal_rule: forwardRef<HTMLElement, NodeViewComponentProps>(
           function HorizontalRule({ nodeProps, ...props }, ref) {
-            return <var ref={ref} {...props} />;
+            return <var {...props} ref={ref} />;
           }
         ),
       },

--- a/src/components/__tests__/ProseMirror.node-view.test.tsx
+++ b/src/components/__tests__/ProseMirror.node-view.test.tsx
@@ -75,7 +75,7 @@ describe("nodeViews prop", () => {
         paragraph: forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
           function Paragraph({ children, nodeProps, ...props }, ref) {
             return (
-              <p ref={ref} {...props}>
+              <p {...props} ref={ref}>
                 {children}
               </p>
             );
@@ -155,7 +155,7 @@ describe("nodeViews prop", () => {
             // re-render when an updated doesn't directly affect us
             useEditorState();
             pos = nodeProps.getPos();
-            return <br ref={ref} {...props} />;
+            return <br {...props} ref={ref} />;
           }
         ),
       },
@@ -278,10 +278,10 @@ describe("nodeViews prop", () => {
             });
             return (
               <input
+                {...props}
                 ref={ref}
                 type="text"
                 defaultValue={nodeProps.node.textContent}
-                {...props}
               />
             );
           }

--- a/src/components/__tests__/ProseMirror.test.tsx
+++ b/src/components/__tests__/ProseMirror.test.tsx
@@ -311,7 +311,7 @@ describe("ProseMirror", () => {
     const Paragraph = forwardRef<HTMLDivElement | null, NodeViewComponentProps>(
       function Paragraph({ nodeProps, children, ...props }, ref) {
         return (
-          <p ref={ref} data-testid="node-view" {...props}>
+          <p {...props} ref={ref} data-testid="node-view">
             {children}
           </p>
         );
@@ -357,7 +357,7 @@ describe("ProseMirror", () => {
               return true;
             });
             return (
-              <button id="button" ref={ref} type="button" {...props}>
+              <button {...props} id="button" ref={ref} type="button">
                 Click me
               </button>
             );

--- a/src/contexts/NodeViewContext.tsx
+++ b/src/contexts/NodeViewContext.tsx
@@ -1,13 +1,11 @@
-import { ForwardRefExoticComponent, RefAttributes, createContext } from "react";
+import { ComponentType, RefAttributes, createContext } from "react";
 
 import { NodeViewComponentProps } from "../components/NodeViewComponentProps.js";
 
 export type NodeViewContextValue = {
   nodeViews: Record<
     string,
-    ForwardRefExoticComponent<
-      NodeViewComponentProps & RefAttributes<HTMLElement>
-    >
+    ComponentType<NodeViewComponentProps & RefAttributes<HTMLElement>>
   >;
 };
 

--- a/src/contexts/NodeViewContext.tsx
+++ b/src/contexts/NodeViewContext.tsx
@@ -1,12 +1,9 @@
-import { ComponentType, RefAttributes, createContext } from "react";
+import { ComponentType, createContext } from "react";
 
 import { NodeViewComponentProps } from "../components/NodeViewComponentProps.js";
 
 export type NodeViewContextValue = {
-  nodeViews: Record<
-    string,
-    ComponentType<NodeViewComponentProps & RefAttributes<HTMLElement>>
-  >;
+  nodeViews: Record<string, ComponentType<NodeViewComponentProps>>;
 };
 
 export const NodeViewContext = createContext(


### PR DESCRIPTION
Hi,

In React 19, [ref is a regular props](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop) which mean that the type of `nodeViews` is a bit too strict when using react 19.

This PR update the type to use `ComponentType` instead of `ForwardRefExoticComponent`.
