### PR TITLE
Drop css-tree package. Pass styles to DOM directly

### DIFF
--- a/.yarn/versions/22ef9f0f.yml
+++ b/.yarn/versions/22ef9f0f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
   },
   "dependencies": {
     "classnames": "^2.3.2",
-    "css-tree": "^3.1.0",
     "react-reconciler": "0.31.0"
   }
 }

--- a/src/props.ts
+++ b/src/props.ts
@@ -1,41 +1,19 @@
 import cx from "classnames";
-import { generate, parse } from "css-tree";
 import { HTMLProps } from "react";
 
-export function kebabCaseToCamelCase(str: string) {
-  return str.replaceAll(/-[a-z]/g, (g) => g[1]?.toUpperCase() ?? "");
-}
-
-/**
- * Converts a CSS style string to an object
- * that can be passed to a React component's
- * `style` prop.
- */
-export function cssToStyles(css: string) {
-  const ast = parse(`* { ${css} }`);
-
-  if (ast.type !== "StyleSheet") return {};
-
-  const rule = ast.children.first;
-  if (rule?.type !== "Rule") return {};
-
-  const block = rule.block;
-  const styles: Record<string, string> = {};
-
-  for (const declaration of block.children) {
-    if (declaration.type !== "Declaration") continue;
-    const property = declaration.property;
-    const value =
-      declaration.value.type === "Raw"
-        ? declaration.value.value
-        : generate(declaration.value);
-    const camelCasePropertyName = property.startsWith("--")
-      ? property
-      : kebabCaseToCamelCase(property);
-    styles[camelCasePropertyName] = value;
+function mergeStyleProps(a: HTMLProps<HTMLElement>, b: HTMLProps<HTMLElement>) {
+  if (!("STYLE" in a)) {
+    if (!("STYLE" in b)) {
+      return undefined;
+    }
+    return b.STYLE as string;
   }
-
-  return styles;
+  if (!("STYLE" in b)) {
+    return a.STYLE as string;
+  }
+  return `${(a.STYLE as string).match(/;\s*$/) ? a.STYLE : `${a.STYLE}`} ${
+    b.STYLE
+  }`;
 }
 
 /**
@@ -51,6 +29,7 @@ export function mergeReactProps(
     ...a,
     ...b,
     className: cx(a.className, b.className),
+    STYLE: mergeStyleProps(a, b),
     style: {
       ...a.style,
       ...b.style,
@@ -73,7 +52,14 @@ export function htmlAttrsToReactProps(
         break;
       }
       case "style": {
-        props.style = cssToStyles(attrValue);
+        // HACK: React expects the `style` prop to be an
+        // object mapping from CSS property name to value.
+        // However, it will pass un-recognized props through
+        // to the underlying DOM element, and HTML attributes
+        // are case insensitive. So we use `STYLE` instead,
+        // which React doesn't intercept, but the DOM treats
+        // as `style`
+        props.STYLE = attrValue;
         break;
       }
       case "autocapitalize": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,7 +1257,6 @@ __metadata:
     "@yarnpkg/sdks": "npm:^3.0.0-rc.38"
     classnames: "npm:^2.3.2"
     concurrently: "npm:^7.6.0"
-    css-tree: "npm:^3.1.0"
     eslint: "npm:^8.33.0"
     eslint-config-prettier: "npm:^8.6.0"
     eslint-import-resolver-typescript: "npm:^3.5.3"
@@ -5266,16 +5265,6 @@ __metadata:
   version: 1.1.1
   resolution: "css-shorthand-properties@npm:1.1.1"
   checksum: 10/f8de209800a3a577a531dc155a6ff6d86fc2688c70c5c4f9fa20073531bab49caa80435d14f7ef7d130d104527c76bd4b2c03d768d4ff56c585727f3c280e24b
-  languageName: node
-  linkType: hard
-
-"css-tree@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "css-tree@npm:3.1.0"
-  dependencies:
-    mdn-data: "npm:2.12.2"
-    source-map-js: "npm:^1.0.1"
-  checksum: 10/e8c5c8e98e3aa4a620fda0b813ce57ccf99281652bf9d23e5cdfc9961c9a93a6769941f9a92e31e65d90f446f42fa83879ab0185206dc7a178d9f656d0913e14
   languageName: node
   linkType: hard
 
@@ -10184,13 +10173,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdn-data@npm:2.12.2":
-  version: 2.12.2
-  resolution: "mdn-data@npm:2.12.2"
-  checksum: 10/854e41715a9358e69f9a530117cd6ca7e71d06176469de8d70b1e629753b6827f5bd730995c16ad3750f3c9bad92230f8e4e178de2b34926b05f5205d27d76af
-  languageName: node
-  linkType: hard
-
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -12859,7 +12841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3


### PR DESCRIPTION
Fixes #38.

It turns out, it's possible to directly pass style strings to the underlying DOM nodes by just... capitalizing the prop name? Quite goofy, but it allows us to entirely drop any CSS parsing functionality, which is great.