### PR TITLE
Fix CustomNodeViews with contentDOMs

### DIFF
--- a/.yarn/versions/ddd813d4.yml
+++ b/.yarn/versions/ddd813d4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch


### PR DESCRIPTION
When we fixed strict/concurrent mode by adding a layout effect that destroyed/reconstructed the node view on mount, we unintentionally broke contentDOM support. This was because we never re-rendered after the node view was reconstructed, so the contentDOM portal still pointed into the old contentDOM, which had been unmounted.

We fix this by forcing a re-render after reconstructing the node view and producing a new contentDOM, thereby forcing a re-render of the portal with the correct contentDOM ref.