### PR TITLE
Don't double-nest marks with unspecified holes

### DIFF
--- a/.yarn/versions/1a93b4cd.yml
+++ b/.yarn/versions/1a93b4cd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/demo/schema.ts
+++ b/demo/schema.ts
@@ -68,7 +68,7 @@ export const schema = new Schema({
   marks: {
     em: {
       toDOM() {
-        return ["em", 0];
+        return ["em"];
       },
       parseDOM: [
         {
@@ -78,7 +78,7 @@ export const schema = new Schema({
     },
     strong: {
       toDOM() {
-        return ["strong", 0];
+        return ["strong"];
       },
       parseDOM: [
         {
@@ -108,7 +108,7 @@ export const schema = new Schema({
         url: { default: "", validate: "string" },
       },
       toDOM(mark) {
-        return ["a", { href: mark.attrs.url }, 0];
+        return ["a", { href: mark.attrs.url }];
       },
       parseDOM: [
         {

--- a/src/components/OutputSpec.tsx
+++ b/src/components/OutputSpec.tsx
@@ -101,7 +101,7 @@ const ForwardedOutputSpec = memo(
     // When the resulting spec contains a hole, that is where the
     // marked content is placed. Otherwise, it is appended to the top node.
     if (isMark && !hasHole(outputSpec)) {
-      content.push(createElement(tagName, props, children));
+      content.push(children);
     }
     return createElement(tagName, props, ...content);
   })


### PR DESCRIPTION
Fixes #44. When we added support for marks with unspecified holes, we unintentionally added a bug where we rendered the entire markup for the mark nested within the initial markup. We just want to render the children in the hole!