### PR TITLE
Quiet React DOM STYLE prop warning in React 19

### DIFF
--- a/.yarn/versions/4206cfbe.yml
+++ b/.yarn/versions/4206cfbe.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/props.ts
+++ b/src/props.ts
@@ -11,9 +11,7 @@ function patchConsoleError() {
     const [message, prop, correction] = data;
     if (
       typeof message === "string" &&
-      message.startsWith(
-        "Warning: Invalid DOM property `%s`. Did you mean `%s`?"
-      ) &&
+      message.includes("Invalid DOM property `%s`. Did you mean `%s`?") &&
       prop === "STYLE" &&
       correction === "style"
     ) {


### PR DESCRIPTION
React 19 dropped the "Warning:" prefix from its warning about casing the `style` prop incorrectly