### PR TITLE
Fix custom node views when strict mode is _off_

### DIFF
--- a/.yarn/versions/a2296abd.yml
+++ b/.yarn/versions/a2296abd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/CustomNodeView.tsx
+++ b/src/components/CustomNodeView.tsx
@@ -99,26 +99,31 @@ export const CustomNodeView = memo(function CustomNodeView({
         );
       }
 
-      if (!customNodeViewRootRef.current) return;
-
-      const { dom } = customNodeViewRef.current;
-      nodeDomRef.current = customNodeViewRootRef.current;
-      customNodeViewRootRef.current.appendChild(dom);
-
-      // Layout effects can run multiple times — if this effect
-      // destroyed and recreated this node view, then we need to
-      // resync the selectNode state
-      if (
-        view?.state.selection instanceof NodeSelection &&
-        view.state.selection.node === nodeRef.current
-      ) {
-        customNodeViewRef.current.selectNode?.();
-      }
-
       // If we've reconstructed the nodeview, then we need to
       // recreate the portal into its contentDOM, which happens
       // during the render. So we need to trigger a re-render!
       forceUpdate();
+    }
+
+    if (!customNodeViewRootRef.current) return;
+
+    const { dom } = customNodeViewRef.current;
+
+    if (customNodeViewRootRef.current.firstChild === dom) {
+      return;
+    }
+
+    nodeDomRef.current = customNodeViewRootRef.current;
+    customNodeViewRootRef.current.appendChild(dom);
+
+    // Layout effects can run multiple times — if this effect
+    // destroyed and recreated this node view, then we need to
+    // resync the selectNode state
+    if (
+      view?.state.selection instanceof NodeSelection &&
+      view.state.selection.node === nodeRef.current
+    ) {
+      customNodeViewRef.current.selectNode?.();
     }
 
     const nodeView = customNodeViewRef.current;


### PR DESCRIPTION
The previous "fix" here unintentionally relied on StrictMode in order to operate correctly. In a non-strict/non-concurrent render, where effect destructors are not called unless their dependencies change, we were never actually appending the dom of the custom node view to the root.

I've confirmed that this now works correctly for _both_ strict and non-strict modes!