### PR TITLE
React 19.1

### DIFF
--- a/.yarn/versions/7c54e89e.yml
+++ b/.yarn/versions/7c54e89e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": minor

--- a/README.md
+++ b/README.md
@@ -27,16 +27,40 @@ releases, and are not guaranteed to work with other versions of
 prosemirror-view. Ensure that your version of prosemirror-view matches the
 version in React ProseMirror's peer dependencies!
 
+_Note_: React ProseMirror does not require a specific verson of React, React
+DOM, or React Reconciler. **However**, you must ensure that your React
+Reconciler version matches your React/React DOM versions.
+
+| React version   | React Reconciler version |
+| --------------- | ------------------------ |
+| 19.x            | 0.32.0                   |
+| >= 18.2.0, < 19 | 0.29.0                   |
+| 18.1.x          | 0.28.0                   |
+| 18.0.x          | 0.27.0                   |
+| 17.x            | 0.26.1                   |
+
 npm:
 
 ```sh
-npm install @handlewithcare/react-prosemirror prosemirror-view@1.37.1 prosemirror-state prosemirror-model
+npm install @handlewithcare/react-prosemirror \
+    react@^19.1.0 \
+    react-dom@^19.1.0 \
+    react-reconciler@0.32.0 \
+    prosemirror-view@1.37.1 \
+    prosemirror-state \
+    prosemirror-model
 ```
 
 yarn:
 
 ```sh
-yarn add @handlewithcare/react-prosemirror prosemirror-view@1.37.1 prosemirror-state prosemirror-model
+yarn add @handlewithcare/react-prosemirror @handlewithcare/react-prosemirror \
+    react@^19.1.0 \
+    react-dom@^19.1.0 \
+    react-reconciler@0.32.0 \
+    prosemirror-view@1.37.1 \
+    prosemirror-state \
+    prosemirror-model
 ```
 
 <!-- toc -->

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "@swc/core": "^1.3.32",
     "@swc/jest": "^0.2.24",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/css-tree": "^2.3.10",
     "@types/jest": "^27.0.0",
     "@types/react": "^18.2.0",
@@ -92,7 +92,7 @@
     "prosemirror-history": "^1.4.1",
     "prosemirror-inputrules": "^1.4.0",
     "prosemirror-keymap": "^1.2.1",
-    "prosemirror-model": "^1.22.3",
+    "prosemirror-model": "^1.25.1",
     "prosemirror-schema-list": "^1.2.2",
     "prosemirror-state": "^1.4.3",
     "prosemirror-tables": "^1.3.7",
@@ -101,6 +101,7 @@
     "prosemirror-view": "1.37.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-reconciler": "^0.29.0",
     "remark-parse": "^11.0.0",
     "rimraf": "^3.0.2",
     "tsx": "^4.19.1",
@@ -113,15 +114,15 @@
     "prosemirror-model": "^1.0.0",
     "prosemirror-state": "^1.0.0",
     "prosemirror-view": "1.37.1",
-    "react": ">=17 <=19.0.0",
-    "react-dom": ">=17 <=19.0.0"
+    "react": ">=17 <=19.1.0",
+    "react-dom": ">=17 <=19.1.0",
+    "react-reconciler": "*"
   },
   "packageManager": "yarn@4.5.3",
   "engines": {
     "node": ">=16.9"
   },
   "dependencies": {
-    "classnames": "^2.3.2",
-    "react-reconciler": "0.31.0"
+    "classnames": "^2.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,8 +1237,8 @@ __metadata:
     "@swc/core": "npm:^1.3.32"
     "@swc/jest": "npm:^0.2.24"
     "@testing-library/dom": "npm:^10.4.0"
-    "@testing-library/react": "npm:^16.0.1"
-    "@testing-library/user-event": "npm:^14.4.3"
+    "@testing-library/react": "npm:^16.3.0"
+    "@testing-library/user-event": "npm:^14.6.1"
     "@types/css-tree": "npm:^2.3.10"
     "@types/jest": "npm:^27.0.0"
     "@types/react": "npm:^18.2.0"
@@ -1278,7 +1278,7 @@ __metadata:
     prosemirror-history: "npm:^1.4.1"
     prosemirror-inputrules: "npm:^1.4.0"
     prosemirror-keymap: "npm:^1.2.1"
-    prosemirror-model: "npm:^1.22.3"
+    prosemirror-model: "npm:^1.25.1"
     prosemirror-schema-list: "npm:^1.2.2"
     prosemirror-state: "npm:^1.4.3"
     prosemirror-tables: "npm:^1.3.7"
@@ -1287,7 +1287,7 @@ __metadata:
     prosemirror-view: "npm:1.37.1"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    react-reconciler: "npm:0.31.0"
+    react-reconciler: "npm:^0.29.0"
     remark-parse: "npm:^11.0.0"
     rimraf: "npm:^3.0.2"
     tsx: "npm:^4.19.1"
@@ -1299,8 +1299,9 @@ __metadata:
     prosemirror-model: ^1.0.0
     prosemirror-state: ^1.0.0
     prosemirror-view: 1.37.1
-    react: ">=17 <=19.0.0"
-    react-dom: ">=17 <=19.0.0"
+    react: ">=17 <=19.1.0"
+    react-dom: ">=17 <=19.1.0"
+    react-reconciler: "*"
   languageName: unknown
   linkType: soft
 
@@ -2751,32 +2752,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^16.0.1":
-  version: 16.0.1
-  resolution: "@testing-library/react@npm:16.0.1"
+"@testing-library/react@npm:^16.3.0":
+  version: 16.3.0
+  resolution: "@testing-library/react@npm:16.3.0"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
   peerDependencies:
     "@testing-library/dom": ^10.0.0
-    "@types/react": ^18.0.0
-    "@types/react-dom": ^18.0.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/904b48881cf5bd208e25899e168f5c99c78ed6d77389544838d9d861a038d2c5c5385863ee9a367436770cbf7d21c5e05a991b9e24a33806e9ac985df2448185
+  checksum: 10/0ee9e31dd0d2396a924682d0e61a4ecc6bfab8eaff23dbf8a72c3c2ce22c116fa578148baeb4de75b968ef99d22e6e6aa0a00dba40286f71184918bb6bb5b06a
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^14.4.3":
-  version: 14.4.3
-  resolution: "@testing-library/user-event@npm:14.4.3"
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 10/0c7c1ee6bacd8faf15e00624ff6815f0cdf2529493c3a0d8ec6878bbedfc7bd4c7600b7a4b7a07302737e71400dc560ee17dc5706291505da09905c8ea3f3cd7
+  checksum: 10/34b74fff56a0447731a94b40d4cf246deb8dbc1c1e3aec93acd1c3377a760bb062e979f1572bb34ec164ad28ee2a391744b42d0d6d6cc16c4ce527e5e09610e1
   languageName: node
   linkType: hard
 
@@ -3073,18 +3074,18 @@ __metadata:
   linkType: hard
 
 "@types/prop-types@npm:*":
-  version: 15.7.5
-  resolution: "@types/prop-types@npm:15.7.5"
-  checksum: 10/5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  version: 15.7.14
+  resolution: "@types/prop-types@npm:15.7.14"
+  checksum: 10/d0c5407b9ccc3dd5fae0ccf9b1007e7622ba5e6f1c18399b4f24dff33619d469da4b9fa918a374f19dc0d9fe6a013362aab0b844b606cfc10676efba3f5f736d
   languageName: node
   linkType: hard
 
 "@types/react-dom@npm:^18.2.0":
-  version: 18.3.5
-  resolution: "@types/react-dom@npm:18.3.5"
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
   peerDependencies:
     "@types/react": ^18.0.0
-  checksum: 10/02095b326f373867498e0eb2b5ebb60f9bd9535db0d757ea13504c4b7d75e16605cf1d43ce7a2e67893d177b51db4357cabb2842fb4257c49427d02da1a14e09
+  checksum: 10/317569219366d487a3103ba1e5e47154e95a002915fdcf73a44162c48fe49c3a57fcf7f57fc6979e70d447112681e6b13c6c3c1df289db8b544df4aab2d318f3
   languageName: node
   linkType: hard
 
@@ -3098,12 +3099,12 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:^18.2.0":
-  version: 18.3.18
-  resolution: "@types/react@npm:18.3.18"
+  version: 18.3.21
+  resolution: "@types/react@npm:18.3.21"
   dependencies:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/7fdd8b853e0d291d4138133f93f8d5c333da918e5804afcea61a923aab4bdfc9bb15eb21a5640959b452972b8715ddf10ffb12b3bd071898b9e37738636463f2
+  checksum: 10/89adc2fe391fd63b620db0aaa10b2be89fad338039415fd748e60c962e47bf2b0f1897cb5226f181eda963f37a1c8ac1bf0b3b29a0e35313bacd0355e5d6c736
   languageName: node
   linkType: hard
 
@@ -11680,12 +11681,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.19.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.22.3, prosemirror-model@npm:^1.8.1":
-  version: 1.22.3
-  resolution: "prosemirror-model@npm:1.22.3"
+"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.19.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.25.1, prosemirror-model@npm:^1.8.1":
+  version: 1.25.1
+  resolution: "prosemirror-model@npm:1.25.1"
   dependencies:
     orderedmap: "npm:^2.0.0"
-  checksum: 10/ea69eb2f9be2c8cc6fb57eff274692d590ff7d5980d173d493f0655fd831e79711ef42171a0cb50c4670ea06d21c32ae1085b7da1e8bd741f195c909c1a81a00
+  checksum: 10/22ebe848ef85f12ce668247918005f92eac14d079ebd6540cd033c0c7fa02f6ded13537bb30f55da1a5d2505dbf9fed2ee75bc54161ec828d2b5d021e81aefb7
   languageName: node
   linkType: hard
 
@@ -11920,14 +11921,14 @@ __metadata:
   linkType: hard
 
 "react-dom@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.0"
+    scheduler: "npm:^0.23.2"
   peerDependencies:
-    react: ^18.2.0
-  checksum: 10/ca5e7762ec8c17a472a3605b6f111895c9f87ac7d43a610ab7024f68cd833d08eda0625ce02ec7178cc1f3c957cf0b9273cdc17aa2cd02da87544331c43b1d21
+    react: ^18.3.1
+  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
   languageName: node
   linkType: hard
 
@@ -11952,14 +11953,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-reconciler@npm:0.31.0":
-  version: 0.31.0
-  resolution: "react-reconciler@npm:0.31.0"
+"react-reconciler@npm:^0.29.0":
+  version: 0.29.2
+  resolution: "react-reconciler@npm:0.29.2"
   dependencies:
-    scheduler: "npm:^0.25.0"
+    loose-envify: "npm:^1.1.0"
+    scheduler: "npm:^0.23.2"
   peerDependencies:
-    react: ^19.0.0
-  checksum: 10/e7235fa08947296c2084a89dc264651fd7cb9dc3a26c3b132b84ecf2a30c46b9b98cd004c30adfe2a24741cd1e49a618858a48080008ce2b4e964a2c4233041e
+    react: ^18.3.1
+  checksum: 10/f9ef98a88ec07efaf520ce4508bc4f499cfbec6c929549b4b802a09c2c7cd1b7b893f197ab0505dc03398a991b4f57d7b6572ae53d2699db74496cadde541cfc
   languageName: node
   linkType: hard
 
@@ -11971,11 +11973,11 @@ __metadata:
   linkType: hard
 
 "react@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/b9214a9bd79e99d08de55f8bef2b7fc8c39630be97c4e29d7be173d14a9a10670b5325e94485f74cd8bff4966ef3c78ee53c79a7b0b9b70cba20aa8973acc694
+  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
   languageName: node
   linkType: hard
 
@@ -12511,19 +12513,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/0c4557aa37bafca44ff21dc0ea7c92e2dbcb298bc62eae92b29a39b029134f02fb23917d6ebc8b1fa536b4184934314c20d8864d156a9f6357f3398aaf7bfda8
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "scheduler@npm:0.25.0"
-  checksum: 10/e661e38503ab29a153429a99203fefa764f28b35c079719eb5efdd2c1c1086522f6653d8ffce388209682c23891a6d1d32fa6badf53c35fb5b9cd0c55ace42de
+  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump max React version to 19.1. Also moves react-reconciler to peer dependencies and adds some guidance on how to install the correct version of it for your react version.