### PR TITLE
Prevent infinite loop when node views passed as direct props

### DIFF
--- a/.yarn/versions/926015dc.yml
+++ b/.yarn/versions/926015dc.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/__tests__/ProseMirror.node-view.test.tsx
+++ b/src/components/__tests__/ProseMirror.node-view.test.tsx
@@ -3,7 +3,11 @@
 import { screen } from "@testing-library/react";
 import { Plugin } from "prosemirror-state";
 import { blockquote, br, doc, p } from "prosemirror-test-builder";
-import { Decoration, DecorationSet } from "prosemirror-view";
+import {
+  Decoration,
+  DecorationSet,
+  ViewMutationRecord,
+} from "prosemirror-view";
 import React, { forwardRef, useEffect } from "react";
 
 import { useEditorState } from "../../hooks/useEditorState.js";
@@ -284,6 +288,312 @@ describe("nodeViews prop", () => {
             );
           }
         ),
+      },
+    });
+
+    const input = screen.getByDisplayValue("input value");
+    input.focus();
+    await browser.keys("z");
+
+    expect(await $(input).getValue()).toBe("input valuez");
+  });
+});
+
+describe("customNodeViews prop", () => {
+  it("can replace a node's representation", async () => {
+    const { view } = tempEditor({
+      doc: doc(p("foo", br())),
+      customNodeViews: {
+        hard_break() {
+          return {
+            dom: document.createElement("var"),
+          };
+        },
+      },
+    });
+    expect(view.dom.querySelector("var")).not.toBeNull();
+  });
+
+  it("can override drawing of a node's content", async () => {
+    const { view } = tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph(node) {
+          const dom = document.createElement("p");
+          dom.appendChild(
+            document.createTextNode(node.textContent.toUpperCase())
+          );
+          return {
+            dom,
+          };
+        },
+      },
+    });
+    expect(view.dom.querySelector("p")!.textContent).toBe("FOO");
+  });
+
+  it("can register its own update method", async () => {
+    const { view } = tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph(node) {
+          const dom = document.createElement("p");
+          dom.textContent = node.textContent.toUpperCase();
+          return {
+            dom,
+            update(node) {
+              dom.textContent = node.textContent.toUpperCase();
+              return true;
+            },
+          };
+        },
+      },
+    });
+    const para = view.dom.querySelector("p")!;
+    view.dispatch(view.state.tr.insertText("a"));
+    expect(view.dom.querySelector("p")).toBe(para);
+    expect(para.textContent).toBe("AFOO");
+  });
+
+  it("allows decoration updates for node views with an update method", async () => {
+    const { view, rerender } = tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph(node) {
+          const dom = document.createElement("p");
+          return {
+            dom,
+            contentDOM: dom,
+            update(node_) {
+              return node.sameMarkup(node_);
+            },
+          };
+        },
+      },
+    });
+
+    rerender({
+      decorations(state) {
+        return DecorationSet.create(state.doc, [
+          Decoration.inline(2, 3, { someattr: "ok" }),
+          Decoration.node(0, 5, { otherattr: "ok" }),
+        ]);
+      },
+    });
+
+    expect(view.dom.querySelector("[someattr]")).not.toBeNull();
+    expect(view.dom.querySelector("[otherattr]")).not.toBeNull();
+  });
+
+  it("can provide a contentDOM property", async () => {
+    const { view } = tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph() {
+          const dom = document.createElement("p");
+          return { dom, contentDOM: dom };
+        },
+      },
+    });
+    const para = view.dom.querySelector("p")!;
+    view.dispatch(view.state.tr.insertText("a"));
+    expect(view.dom.querySelector("p")).toBe(para);
+    expect(para.textContent).toBe("afoo");
+  });
+
+  // Skipping for now... We don't use a mutation observer to
+  // detect changes, so we don't have an obvious place to call
+  // ignoreMutation at the moment.
+  // TODO: Add this check to beforeInputPlugin
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("has its ignoreMutation method called", async () => {
+    let mutation: ViewMutationRecord | undefined;
+    const { view } = tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph() {
+          const dom = document.createElement("div");
+          const contentDOM = document.createElement("p");
+          const info = document.createElement("x-info");
+          dom.append(contentDOM, info);
+          return {
+            dom,
+            contentDOM,
+            ignoreMutation: (m) => {
+              mutation = m;
+              return true;
+            },
+          };
+        },
+      },
+    });
+    expect(mutation).toBeFalsy();
+    view.dispatch(view.state.tr.delete(3, 5));
+    expect(mutation).toBeTruthy();
+    expect((mutation!.target as HTMLElement).tagName).toBe("X-INFO");
+  });
+
+  it("has its destroy method called", async () => {
+    let destroyed = 0;
+    const { view } = tempEditor({
+      doc: doc(p("foo", br())),
+      customNodeViews: {
+        hard_break() {
+          return {
+            dom: document.createElement("br"),
+            destroy: () => destroyed++,
+          };
+        },
+      },
+    });
+    // TODO: This gets destroyed once essentially
+    // immediately, due to the dummy EditorView that
+    // we create and then immediately destroy for SSR
+    expect(destroyed).toBe(1);
+    view.dispatch(view.state.tr.delete(3, 5));
+    expect(destroyed).toBe(2);
+  });
+
+  it("can query its own position", async () => {
+    let get: () => number | undefined;
+    const { view } = tempEditor({
+      doc: doc(blockquote(p("abc"), p("foo", br()))),
+      customNodeViews: {
+        hard_break(_n, _v, getPos) {
+          expect(getPos()).toBe(10);
+          get = getPos;
+          return { dom: document.createElement("br") };
+        },
+      },
+    });
+    expect(get!()).toBe(10);
+    view.dispatch(view.state.tr.insertText("a"));
+    expect(get!()).toBe(11);
+  });
+
+  it("has access to outer decorations", async () => {
+    const plugin = new Plugin({
+      state: {
+        init() {
+          return null;
+        },
+        apply(tr, prev) {
+          return tr.getMeta("setDeco") || prev;
+        },
+      },
+      props: {
+        decorations(this: Plugin, state) {
+          const deco = this.getState(state);
+          return (
+            deco &&
+            DecorationSet.create(state.doc, [
+              Decoration.inline(0, state.doc.content.size, {}, {
+                name: deco,
+              } as any),
+            ])
+          );
+        },
+      },
+    });
+    const { view } = tempEditor({
+      doc: doc(p("foo", br())),
+      plugins: [plugin],
+      customNodeViews: {
+        hard_break(_n, _v, _p, deco) {
+          const dom = document.createElement("var");
+          function update(deco: readonly Decoration[]) {
+            dom.textContent = deco.length ? deco[0]!.spec.name : "[]";
+          }
+          update(deco);
+          return {
+            dom,
+            update(_, deco) {
+              update(deco);
+              return true;
+            },
+          };
+        },
+      },
+    });
+    expect(view.dom.querySelector("var")!.textContent).toBe("[]");
+    view.dispatch(view.state.tr.setMeta("setDeco", "foo"));
+    expect(view.dom.querySelector("var")!.textContent).toBe("foo");
+    view.dispatch(view.state.tr.setMeta("setDeco", "bar"));
+    expect(view.dom.querySelector("var")!.textContent).toBe("bar");
+  });
+
+  it("provides access to inner decorations in the constructor", async () => {
+    tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph(_node, _v, _pos, _outer, innerDeco) {
+          const dom = document.createElement("p");
+          expect(
+            (innerDeco as DecorationSet)
+              .find()
+              .map((d) => `${d.from}-${d.to}`)
+              .join()
+          ).toBe("1-2");
+          return { dom, contentDOM: dom };
+        },
+      },
+      decorations(state) {
+        return DecorationSet.create(state.doc, [
+          Decoration.inline(2, 3, { someattr: "ok" }),
+          Decoration.node(0, 5, { otherattr: "ok" }),
+        ]);
+      },
+    });
+  });
+
+  it("provides access to inner decorations in the update method", async () => {
+    let innerDecos: string[] = [];
+    const { rerender } = tempEditor({
+      doc: doc(p("foo")),
+      customNodeViews: {
+        paragraph(node) {
+          const dom = document.createElement("p");
+          return {
+            dom,
+            contentDOM: dom,
+            update(node_, _, innerDecoSet) {
+              innerDecos = (innerDecoSet as DecorationSet)
+                .find()
+                .map((d) => `${d.from}-${d.to}`);
+              return node.sameMarkup(node_);
+            },
+          };
+        },
+      },
+    });
+
+    rerender({
+      decorations(state) {
+        return DecorationSet.create(state.doc, [
+          Decoration.inline(2, 3, { someattr: "ok" }),
+          Decoration.node(0, 5, { otherattr: "ok" }),
+        ]);
+      },
+    });
+
+    expect(innerDecos.join()).toBe("1-2");
+  });
+
+  it("can provide a stopEvent hook", async () => {
+    tempEditor({
+      doc: doc(p("input value")),
+      customNodeViews: {
+        paragraph(node) {
+          const dom = document.createElement("input");
+          dom.value = node.textContent;
+
+          return {
+            dom,
+            stopEvent() {
+              return true;
+            },
+          };
+        },
       },
     });
 

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -109,6 +109,8 @@ export class ReactEditorView extends EditorView {
     // @ts-expect-error We're making use of knowledge of internal attributes here
     this.docView.dom.replaceChildren();
     // @ts-expect-error We're making use of knowledge of internal attributes here
+    this.nodeViews = buildNodeViews(this);
+    // @ts-expect-error We're making use of knowledge of internal attributes here
     this.docView = props.docView;
   }
 


### PR DESCRIPTION
Fixes #28.

We were never setting `this.nodeViews` in the `ReactEditorView` constructor, so the latter `checkNodeViews` check was always failing, causing an infinite loop.

I added a whole test suite for custom node views so that we don't run into this kind of thing again without warning!