### PR TITLE
Fix Enter key not working on mobile Android devices running Chrome

### DIFF
--- a/.yarn/versions/22f7023f.yml
+++ b/.yarn/versions/22f7023f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@handlewithcare/react-prosemirror",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@handlewithcare/react-prosemirror",
-  "version": "2.4.4",
+  "version": "2.4.3",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/src/components/__tests__/ProseMirror.mobile.test.tsx
+++ b/src/components/__tests__/ProseMirror.mobile.test.tsx
@@ -1,0 +1,66 @@
+import { baseKeymap } from "prosemirror-commands";
+import { keymap } from "prosemirror-keymap";
+import { TextSelection } from "prosemirror-state";
+import { br, doc, p, schema } from "prosemirror-test-builder";
+import { EditorView } from "prosemirror-view";
+
+import { beforeInputPlugin } from "../../plugins/beforeInputPlugin.js";
+import { tempEditor } from "../../testing/editorViewTestHelpers.js";
+
+describe("ProseMirror Mobile", () => {
+  it("handles insertParagraph with mobile Enter key", async () => {
+    const { view } = tempEditor({
+      doc: doc(p("Hello")),
+      plugins: createPlugins(),
+    });
+
+    setCursorAtEnd(view);
+    view.focus();
+
+    await browser.keys("Enter");
+    expect(view.state.doc).toEqual(doc(p("Hello"), p()));
+  });
+
+  it("handles insertLineBreak with mobile Shift+Enter", async () => {
+    const { view } = tempEditor({
+      doc: doc(p("Hello")),
+      plugins: createPlugins(),
+    });
+
+    setCursorAtEnd(view);
+    view.focus();
+
+    await browser.keys(["Shift", "Enter"]);
+    expect(view.state.doc).toEqual(doc(p("Hello", br())));
+  });
+});
+
+function createPlugins() {
+  return [
+    keymap({
+      "Shift-Enter": (state, dispatch) => {
+        const { tr } = state;
+        if (schema.nodes.hard_break) {
+          tr.insert(tr.selection.from, schema.nodes.hard_break.create());
+          dispatch?.(tr);
+          return true;
+        }
+
+        return false;
+      },
+    }),
+    keymap(baseKeymap),
+    beforeInputPlugin(() => {
+      // no-op as this doesn't matter for this test
+    }),
+  ];
+}
+
+function setCursorAtEnd(view: EditorView) {
+  const endPos = view.state.doc.content.size - 1;
+  view.dispatch(
+    view.state.tr.setSelection(
+      TextSelection.near(view.state.doc.resolve(endPos))
+    )
+  );
+}

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -116,7 +116,6 @@ export function beforeInputPlugin(
         beforeinput(view, event) {
           event.preventDefault();
           switch (event.inputType) {
-            // insertParagraph and insertLineBreak
             case "insertParagraph":
             case "insertLineBreak": {
               // Fire a synthetic keydown event to trigger ProseMirror's keymap

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -116,9 +116,26 @@ export function beforeInputPlugin(
         beforeinput(view, event) {
           event.preventDefault();
           switch (event.inputType) {
-            case "insertCompositionText": {
-              if (event.data === null) break;
+            // insertParagraph and insertLineBreak
+            case "insertParagraph":
+            case "insertLineBreak": {
+              // Fire a synthetic keydown event to trigger ProseMirror's keymap
+              const keyEvent = new KeyboardEvent("keydown", {
+                bubbles: true,
+                cancelable: true,
+                key: "Enter",
+                code: "Enter",
+                keyCode: 13,
+                shiftKey: event.inputType === "insertLineBreak",
+              });
 
+              // Use someProp to directly call ProseMirror handlers
+              return (
+                view.someProp("handleKeyDown", (f) => f(view, keyEvent)) ??
+                false
+              );
+            }
+            case "insertCompositionText": {
               compositionText = event.data;
               break;
             }

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -2,6 +2,8 @@ import "@wdio/types";
 
 import viteConfig from "./vite.config.js";
 
+const mobileSpecs = ["./src/components/__tests__/ProseMirror.mobile.test.tsx"];
+
 export const config: WebdriverIO.Config = {
   //
   // ====================
@@ -34,6 +36,11 @@ export const config: WebdriverIO.Config = {
   exclude: [
     // 'path/to/excluded/files'
   ],
+
+  // Define suites for targeted test runs
+  suites: {
+    mobile: mobileSpecs,
+  },
   //
   // ============
   // Capabilities
@@ -59,9 +66,20 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       browserName: "chrome",
+      "wdio:exclude": mobileSpecs,
     },
     {
       browserName: "firefox",
+      "wdio:exclude": mobileSpecs,
+    },
+    {
+      browserName: "chrome",
+      "wdio:specs": mobileSpecs,
+      "goog:chromeOptions": {
+        mobileEmulation: {
+          deviceName: "Pixel 7",
+        },
+      },
     },
   ],
 


### PR DESCRIPTION
This PR adds a fix for #70. 

This works by updating `src/plugins/beforeInputPlugin.ts` to handle `insertParagraph` and `insertLineBreak` event types and emits an "Enter" key event to any registered `keydown` handlers on the ProseMirror view. 

I've included wdio tests and split out mobile tests into their own suite, which makes it convenient to run via `npx wdio run ./wdio.conf.ts --suite mobile`.  Fortunately, it was pretty easy to add tests it turns out that wdio supports mobile emulation via: 

```
"goog:chromeOptions": {
        mobileEmulation: {
          deviceName: "Pixel 7",
        },
      },
```