### PR TITLE
tidy: remove duplicate dependency from yarn installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install @handlewithcare/react-prosemirror \
 yarn:
 
 ```sh
-yarn add @handlewithcare/react-prosemirror @handlewithcare/react-prosemirror \
+yarn add @handlewithcare/react-prosemirror \
     react@^19.1.0 \
     react-dom@^19.1.0 \
     react-reconciler@0.32.0 \


### PR DESCRIPTION
Hey there 👋

I was reading through the documentation and noticed that the yarn installation instructions listed `@handlewithcare/react-prosemirror` twice, so here's a tiny change for removing that extra item.

Thanks for the awesome library, cheers 🙌 