### PR TITLE
Incorporate missed iterDeco fixes from prosemirror-view

### DIFF
--- a/.yarn/versions/1bd89dbb.yml
+++ b/.yarn/versions/1bd89dbb.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/decorations/internalTypes.ts
+++ b/src/decorations/internalTypes.ts
@@ -2,6 +2,8 @@ import { Node } from "prosemirror-model";
 import { Mapping } from "prosemirror-transform";
 import { Decoration, DecorationSet, DecorationSource } from "prosemirror-view";
 
+import { DecorationType } from "./ReactWidgetType.js";
+
 export interface InternalDecorationSource {
   /// Map the set of decorations in response to a change in the
   /// document.
@@ -21,5 +23,8 @@ export interface InternalDecorationSet extends InternalDecorationSource {
 }
 
 export interface InternalDecoration extends Decoration {
+  type: DecorationType;
   copy(from: number, to: number): Decoration;
+  widget: boolean;
+  inline: boolean;
 }

--- a/src/decorations/viewDecorations.tsx
+++ b/src/decorations/viewDecorations.tsx
@@ -201,13 +201,8 @@ export function viewDecorations(
     const result = f(view.state);
     if (result && result != empty) found.push(result);
   });
-  // We don't have access to types for view.cursorWrapper here
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (cursorWrapper) {
-    found.push(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      DecorationSet.create(view.state.doc, [cursorWrapper])
-    );
+    found.push(DecorationSet.create(view.state.doc, [cursorWrapper]));
   }
   const previous = ViewDecorationsCache.get(view);
   if (!previous) {


### PR DESCRIPTION
Somehow we missed this bug fix to iterDecos from way back in 1.31.8: https://github.com/ProseMirror/prosemirror-view/commit/d48818c2f122c8c4b23b2b6bb9673462fc17af57. The result was that overlapping inline decorations that ended at the beginning of a block node could result in iterDecos emitting erroneous widget decorations, which then crashed the NativeWidgetView.