### PR TITLE
Type safe style prop

### DIFF
--- a/.yarn/versions/23c9f997.yml
+++ b/.yarn/versions/23c9f997.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/props.ts
+++ b/src/props.ts
@@ -24,18 +24,16 @@ function patchConsoleError() {
 }
 
 function mergeStyleProps(a: HTMLProps<HTMLElement>, b: HTMLProps<HTMLElement>) {
-  if (!("STYLE" in a)) {
-    if (!("STYLE" in b)) {
+  if (!("STYLE" in a) || typeof a.STYLE !== "string") {
+    if (!("STYLE" in b) || typeof b.STYLE !== "string") {
       return undefined;
     }
-    return b.STYLE as string;
+    return b.STYLE;
   }
-  if (!("STYLE" in b)) {
-    return a.STYLE as string;
+  if (!("STYLE" in b) || typeof b.STYLE !== "string") {
+    return a.STYLE;
   }
-  return `${(a.STYLE as string).match(/;\s*$/) ? a.STYLE : `${a.STYLE}`} ${
-    b.STYLE
-  }`;
+  return `${a.STYLE.match(/;\s*$/) ? a.STYLE : `${a.STYLE};`} ${b.STYLE}`;
 }
 
 /**


### PR DESCRIPTION
Fixes two issues:

1. If one style prop is missing a semicolon, we should automatically insert it (this is what prosemirror-view does) when merging
2. If the style prop exists but is not a string (e.g. undefined, which is a valid value), we should treat it as if it didn't exist.