### PR TITLE
Only add text hack nodes to textblocks

### DIFF
--- a/.yarn/versions/a7d451c4.yml
+++ b/.yarn/versions/a7d451c4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/ChildNodeViews.tsx
+++ b/src/components/ChildNodeViews.tsx
@@ -261,10 +261,12 @@ function createKey(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (widget as any).type.spec.key;
 
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Widget at position ${pos} doesn't have a key specified. This may cause issues.`
-    );
+    if (type === "widget") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Widget at position ${pos} doesn't have a key specified. React ProseMirror will generate a key partially based on this widget’s index into its parent’s children. This can cause issues if there are multiple adjacent widgets.`
+      );
+    }
     return `${key}-${index}`;
   }
 

--- a/src/components/ChildNodeViews.tsx
+++ b/src/components/ChildNodeViews.tsx
@@ -529,20 +529,22 @@ export const ChildNodeViews = memo(function ChildNodeViews({
 
   const childElements = createChildElements(children, getInnerPos);
 
-  const lastChild = children[children.length - 1];
+  if (node.isTextblock) {
+    const lastChild = children[children.length - 1];
 
-  if (
-    !lastChild ||
-    lastChild.type !== "node" ||
-    (lastChild.node.isInline && !lastChild.node.isText) ||
-    // RegExp.test actually handles undefined just fine
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    /\n$/.test(lastChild.node.text!)
-  ) {
-    childElements.push(
-      <SeparatorHackView getPos={getInnerPos} key="trailing-hack-img" />,
-      <TrailingHackView getPos={getInnerPos} key="trailing-hack-br" />
-    );
+    if (
+      !lastChild ||
+      lastChild.type !== "node" ||
+      (lastChild.node.isInline && !lastChild.node.isText) ||
+      // RegExp.test actually handles undefined just fine
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      /\n$/.test(lastChild.node.text!)
+    ) {
+      childElements.push(
+        <SeparatorHackView getPos={getInnerPos} key="trailing-hack-img" />,
+        <TrailingHackView getPos={getInnerPos} key="trailing-hack-br" />
+      );
+    }
   }
 
   return <>{childElements}</>;


### PR DESCRIPTION
Addresses #63 

This was just a missing condition on our part. The result was that we sometimes added hack nodes to blocks that had blocks as children, which caused incorrect rendering behavior.

Also, I've decided that it's actually safe to use index-based keys for native widgets. They don't have any state, and we confirm that their dom matches their props on every render, so there's no risk of state mismatches if React swaps the props for a given NativeWidgetView component, if the order changes. As such, I've limited the warning about giving a key to widgets to react widgets.