### PR TITLE
Fix composition cancel

### DIFF
--- a/.yarn/versions/7039d285.yml
+++ b/.yarn/versions/7039d285.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useNodeViewDescriptor.ts
+++ b/src/hooks/useNodeViewDescriptor.ts
@@ -168,7 +168,7 @@ export function useNodeViewDescriptor(
         childDesc.text = textDOM.data;
         childDesc.textDOM.pmViewDesc = childDesc;
 
-        // @ts-expect-error ???
+        // @ts-expect-error Internal property -- input
         view?.input.compositionNodes.push(childDesc);
       }
     }

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -53,7 +53,6 @@ function insertText(
 export function beforeInputPlugin(
   setCursorWrapper: (deco: Decoration | null) => void
 ) {
-  let compositionText: string | null = null;
   let compositionMarks: readonly Mark[] | null = null;
   return new Plugin({
     props: {
@@ -90,15 +89,13 @@ export function beforeInputPlugin(
         compositionupdate() {
           return true;
         },
-        compositionend(view) {
+        compositionend(view, event) {
           // @ts-expect-error Internal property - input
           view.input.composing = false;
-          if (compositionText === null) return;
 
-          insertText(view, compositionText, {
+          insertText(view, event.data, {
             // TODO: Rather than busting the reactKey cache here,
-            // which is pretty blunt and doesn't work for
-            // multi-node replacements, we should attempt to
+            // which is pretty blunt, we should attempt to
             // snapshot the selected DOM during compositionstart
             // and restore it before we end the composition.
             // This should allow React to successfully clean up
@@ -108,7 +105,6 @@ export function beforeInputPlugin(
             marks: compositionMarks,
           });
 
-          compositionText = null;
           compositionMarks = null;
           setCursorWrapper(null);
           return true;
@@ -133,10 +129,6 @@ export function beforeInputPlugin(
                 view.someProp("handleKeyDown", (f) => f(view, keyEvent)) ??
                 false
               );
-            }
-            case "insertCompositionText": {
-              compositionText = event.data;
-              break;
             }
             case "insertReplacementText": {
               const ranges = event.getTargetRanges();

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -4,8 +4,7 @@ import { Decoration, EditorView } from "prosemirror-view";
 
 import { CursorWrapper } from "../components/CursorWrapper.js";
 import { widget } from "../decorations/ReactWidgetType.js";
-
-import { reactKeysPluginKey } from "./reactKeys.js";
+import { DOMNode } from "../dom.js";
 
 function insertText(
   view: EditorView,
@@ -31,21 +30,6 @@ function insertText(
 
   tr.insertText(eventData, from, to);
 
-  if (options.bust) {
-    const $from = view.state.doc.resolve(from);
-    const sharedAncestorDepth = $from.sharedDepth(to);
-    const sharedAncestorPos = $from.start(sharedAncestorDepth);
-
-    const parentKey = reactKeysPluginKey
-      .getState(view.state)
-      ?.posToKey.get(sharedAncestorPos - 1);
-
-    tr.setMeta(reactKeysPluginKey, {
-      type: "bustKey",
-      payload: { key: parentKey },
-    });
-  }
-
   view.dispatch(tr);
   return true;
 }
@@ -54,6 +38,7 @@ export function beforeInputPlugin(
   setCursorWrapper: (deco: Decoration | null) => void
 ) {
   let compositionMarks: readonly Mark[] | null = null;
+  const precompositionSnapshot: DOMNode[] = [];
   return new Plugin({
     props: {
       handleDOMEvents: {
@@ -64,23 +49,23 @@ export function beforeInputPlugin(
 
           const $pos = state.selection.$from;
 
-          if (
-            state.selection.empty &&
-            (state.storedMarks ||
-              (!$pos.textOffset &&
-                $pos.parentOffset &&
-                $pos.nodeBefore?.marks.some(
-                  (m) => m.type.spec.inclusive === false
-                )))
-          ) {
+          compositionMarks = state.storedMarks ?? $pos.marks();
+          if (compositionMarks) {
             setCursorWrapper(
               widget(state.selection.from, CursorWrapper, {
                 key: "cursor-wrapper",
-                marks: state.storedMarks ?? $pos.marks(),
+                marks: compositionMarks,
               })
             );
           }
-          compositionMarks = state.storedMarks ?? $pos.marks();
+
+          // Snapshot the siblings of the node that contains the
+          // current cursor. We'll restore this later, so that React
+          // doesn't panic about unknown DOM nodes.
+          const { node: parent } = view.domAtPos($pos.pos);
+          parent.childNodes.forEach((node) => {
+            precompositionSnapshot.push(node);
+          });
 
           // @ts-expect-error Internal property - input
           view.input.composing = true;
@@ -93,19 +78,39 @@ export function beforeInputPlugin(
           // @ts-expect-error Internal property - input
           view.input.composing = false;
 
-          insertText(view, event.data, {
-            // TODO: Rather than busting the reactKey cache here,
-            // which is pretty blunt, we should attempt to
-            // snapshot the selected DOM during compositionstart
-            // and restore it before we end the composition.
-            // This should allow React to successfully clean up
-            // and insert the newly composed text, without requiring
-            // any remounts
-            bust: true,
-            marks: compositionMarks,
+          const { state } = view;
+          const { node: parent } = view.domAtPos(state.selection.from);
+
+          // Restore the snapshot of the parent node's children
+          // from before the composition started. This gives us a
+          // clean slate from which to dispatch our transaction
+          // and trigger a React update.
+          precompositionSnapshot.forEach((prevNode, i) => {
+            if (parent.childNodes.length <= i) {
+              parent.appendChild(prevNode);
+              return;
+            }
+            parent.replaceChild(prevNode, parent.childNodes.item(i));
           });
 
+          if (parent.childNodes.length > precompositionSnapshot.length) {
+            for (
+              let i = precompositionSnapshot.length;
+              i < parent.childNodes.length;
+              i++
+            ) {
+              parent.removeChild(parent.childNodes.item(i));
+            }
+          }
+
+          if (event.data) {
+            insertText(view, event.data, {
+              marks: compositionMarks,
+            });
+          }
+
           compositionMarks = null;
+          precompositionSnapshot.splice(0, precompositionSnapshot.length);
           setCursorWrapper(null);
           return true;
         },

--- a/src/plugins/reactKeys.ts
+++ b/src/plugins/reactKeys.ts
@@ -47,8 +47,12 @@ export function reactKeys() {
        * node was deleted.
        */
       apply(tr, value, _, newState) {
-        if (!tr.docChanged || composing) return value;
         const meta = tr.getMeta(reactKeysPluginKey);
+
+        if ((!tr.docChanged && meta?.type !== "bustKey") || composing) {
+          return value;
+        }
+
         const keyToBust = meta?.type === "bustKey" && meta.payload.key;
 
         const next = {

--- a/src/plugins/reactKeys.ts
+++ b/src/plugins/reactKeys.ts
@@ -47,13 +47,9 @@ export function reactKeys() {
        * node was deleted.
        */
       apply(tr, value, _, newState) {
-        const meta = tr.getMeta(reactKeysPluginKey);
-
-        if ((!tr.docChanged && meta?.type !== "bustKey") || composing) {
+        if (!tr.docChanged || composing) {
           return value;
         }
-
-        const keyToBust = meta?.type === "bustKey" && meta.payload.key;
 
         const next = {
           posToKey: new Map<number, string>(),
@@ -66,14 +62,8 @@ export function reactKeys() {
           const { pos: newPos, deleted } = tr.mapping.mapResult(pos);
           if (deleted) continue;
 
-          let newKey = key;
-
-          if (keyToBust === key) {
-            newKey = createNodeKey();
-          }
-
-          next.posToKey.set(newPos, newKey);
-          next.keyToPos.set(newKey, newPos);
+          next.posToKey.set(newPos, key);
+          next.keyToPos.set(key, newPos);
         }
         newState.doc.descendants((_, pos) => {
           if (next.posToKey.has(pos)) return true;


### PR DESCRIPTION
Fixes #65.

The issue here was that we didn't bust the reactKeys cache after an aborted composition, only a successful one. But the browser always doesn't restore the pre-composition DOM after an aborted composition, leading to a React panic about DOM nodes that it doesn't know about. The quick fix there was to make sure that the bustKey meta was dispatched even on an aborted composition.

This was still something of a hack, and it had negative implications for writers in languages other than English. The cache busting works by producing a new `key` for the parent node of the newly composed text, which means that React will unmount and remount that parent node. For many languages (e.g. Japanese and Chinese), this would result on a full remount _on every character composition_. This has serious performance implications!

I'm trying another tack here, which I think will ultimately be more robust. Now, we snapshot the parent DOM node's children at the beginning of a composition, and then restore exactly those nodes after the composition. This essentially undoes the composition, leaving the DOM exactly as it was beforehand. This means that React still owns all of the DOM nodes, and won't panic when asked to update. Then we dispatch a plain insertText, as normal, which functions just like a non-composition insertText.