### PR TITLE
Handle compositionend potentially being dispatched before compositionstart

### DIFF
--- a/.yarn/versions/080ab2a3.yml
+++ b/.yarn/versions/080ab2a3.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch


### PR DESCRIPTION
Well, this is a crazy one.

On macOS, in Safari, the OS will sometimes use compositions to suggest autocompletions. But for some reason, they do this by _only_ dispatching a compositionend event, with no associated compositionstart or compositionupdate. To be clear, the compositionend is dispatched when the suggestion is shown, not when the user selects it - I don't know why an event needs to be dispatched here at all, and certainly not why it would be a compositionend without a start.

Anyway, we need to handle the case where compositionend happens before compositionstart, apparently!