### PR TITLE
Allow arbitrary data in widget specs

### DIFF
--- a/.yarn/versions/2a653a29.yml
+++ b/.yarn/versions/2a653a29.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/decorations/ReactWidgetType.ts
+++ b/src/decorations/ReactWidgetType.ts
@@ -39,6 +39,7 @@ type ReactWidgetSpec = {
   stopEvent?: (event: Event) => boolean;
   ignoreSelection?: boolean;
   key?: string;
+  [key: string]: unknown;
 };
 
 const noSpec = { side: 0 };


### PR DESCRIPTION
This is allowed by prosemirror's `Decoration.widget`, I must have just missed it in the original types.