### PR TITLE
Don't pass plugins to super constructor

### DIFF
--- a/.yarn/versions/b34912b2.yml
+++ b/.yarn/versions/b34912b2.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -81,9 +81,7 @@ export class ReactEditorView extends EditorView {
     super(place, {
       state: EditorState.create({
         schema: props.state.schema,
-        plugins: props.state.plugins,
       }),
-      plugins: props.plugins,
     });
     cleanup();
     this.ready = props.ready;


### PR DESCRIPTION
Alternative to #96. I can't remember exactly why I was passing the plugins in the first place, but I can't see any reason it would be necessary from inspecting the code. Also, empirically, things seem to work fine without it.