### PR TITLE
Add react-reconciler as peer dependency

### DIFF
--- a/.yarn/versions/c7412ae7.yml
+++ b/.yarn/versions/c7412ae7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "prosemirror-state": "^1.0.0",
     "prosemirror-view": "1.39.2",
     "react": ">=17 <=19.1.0",
-    "react-dom": ">=17 <=19.1.0"
+    "react-dom": ">=17 <=19.1.0",
+    "react-reconciler": ">=0.26.1 <=0.32.0"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,6 +1505,7 @@ __metadata:
     prosemirror-view: 1.39.2
     react: ">=17 <=19.1.0"
     react-dom: ">=17 <=19.1.0"
+    react-reconciler: ">=0.26.1 <=0.32.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Thank you for sharing this great library!

This is a pretty minor change, but I think react-reconciler should be a peer dep? Let me know if I'm missing some reason why this isn't desirable.

Either way, really appreciate this project and thanks again.