### PR TITLE
refactor: use offset refs for position functions

### DIFF
--- a/.yarn/versions/f7b1387d.yml
+++ b/.yarn/versions/f7b1387d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/CustomNodeView.tsx
+++ b/src/components/CustomNodeView.tsx
@@ -6,7 +6,6 @@ import {
   NodeView as NodeViewT,
 } from "prosemirror-view";
 import React, {
-  MutableRefObject,
   cloneElement,
   createElement,
   memo,
@@ -29,7 +28,7 @@ import { ChildNodeViews, wrapInDeco } from "./ChildNodeViews.js";
 interface Props {
   customNodeView: NodeViewConstructor;
   node: Node;
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
   innerDeco: DecorationSource;
   outerDeco: readonly Decoration[];
 }
@@ -49,7 +48,6 @@ export const CustomNodeView = memo(function CustomNodeView({
   const domRef = useRef<HTMLElement | null>(null);
   const nodeDomRef = useRef<HTMLElement | null>(null);
   const contentDomRef = useRef<HTMLElement | null>(null);
-  const getPosFunc = useRef(() => getPos.current()).current;
 
   const nodeRef = useRef(node);
   nodeRef.current = node;
@@ -74,7 +72,7 @@ export const CustomNodeView = memo(function CustomNodeView({
       customNodeViewRef.current = customNodeView(
         nodeRef.current,
         view,
-        getPosFunc,
+        getPos,
         outerDecoRef.current,
         innerDecoRef.current
       );
@@ -129,7 +127,7 @@ export const CustomNodeView = memo(function CustomNodeView({
     // _has_ to be called after this hook, so that the effects run
     // in the correct order
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [customNodeView, getPosFunc, view]);
+  }, [customNodeView, getPos, view]);
 
   useClientLayoutEffect(() => {
     if (!customNodeView || !customNodeViewRef.current) return;
@@ -148,14 +146,14 @@ export const CustomNodeView = memo(function CustomNodeView({
     customNodeViewRef.current = customNodeView(
       nodeRef.current,
       view,
-      getPosFunc,
+      getPos,
       outerDecoRef.current,
       innerDecoRef.current
     );
     const { dom } = customNodeViewRef.current;
     nodeDomRef.current = customNodeViewRootRef.current;
     customNodeViewRootRef.current.appendChild(dom);
-  }, [customNodeView, view, innerDeco, node, outerDeco, getPos, getPosFunc]);
+  }, [customNodeView, view, innerDeco, node, outerDeco, getPos]);
 
   const {
     childDescriptors,
@@ -165,7 +163,7 @@ export const CustomNodeView = memo(function CustomNodeView({
     setIgnoreMutation,
   } = useNodeViewDescriptor(
     node,
-    getPosFunc,
+    getPos,
     domRef,
     nodeDomRef,
     innerDeco,
@@ -192,7 +190,7 @@ export const CustomNodeView = memo(function CustomNodeView({
     customNodeViewRef.current = customNodeView(
       nodeRef.current,
       view,
-      () => getPos.current(),
+      getPos,
       outerDecoRef.current,
       innerDecoRef.current
     );

--- a/src/components/DocNodeView.tsx
+++ b/src/components/DocNodeView.tsx
@@ -22,11 +22,9 @@ import { useNodeViewDescriptor } from "../hooks/useNodeViewDescriptor.js";
 
 import { ChildNodeViews, wrapInDeco } from "./ChildNodeViews.js";
 
-const getPos = {
-  current() {
-    return -1;
-  },
-};
+function getPos() {
+  return -1;
+}
 
 export type DocNodeViewProps = {
   className?: string;
@@ -60,7 +58,7 @@ export const DocNodeView = memo(
 
     const { childDescriptors, nodeViewDescRef } = useNodeViewDescriptor(
       node,
-      () => getPos.current(),
+      getPos,
       innerRef,
       innerRef,
       innerDeco,

--- a/src/components/MarkView.tsx
+++ b/src/components/MarkView.tsx
@@ -1,6 +1,5 @@
 import { Mark } from "prosemirror-model";
 import React, {
-  MutableRefObject,
   ReactNode,
   forwardRef,
   memo,
@@ -18,7 +17,7 @@ import { OutputSpec } from "./OutputSpec.js";
 
 type Props = {
   mark: Mark;
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
   children: ReactNode;
 };
 
@@ -65,7 +64,7 @@ export const MarkView = memo(
         viewDescRef.current = new MarkViewDesc(
           parentRef.current,
           childDescriptors.current,
-          () => getPos.current(),
+          getPos,
           mark,
           domRef.current,
           firstChildDesc?.dom.parentElement ?? domRef.current,
@@ -81,7 +80,6 @@ export const MarkView = memo(
         viewDescRef.current.spec.contentDOM = viewDescRef.current.contentDOM =
           firstChildDesc?.dom.parentElement ?? domRef.current;
         viewDescRef.current.mark = mark;
-        viewDescRef.current.getPos = () => getPos.current();
       }
       if (!siblingsRef.current.includes(viewDescRef.current)) {
         siblingsRef.current.push(viewDescRef.current);

--- a/src/components/NativeWidgetView.tsx
+++ b/src/components/NativeWidgetView.tsx
@@ -1,5 +1,5 @@
 import { Decoration, EditorView } from "prosemirror-view";
-import React, { MutableRefObject, useContext, useRef } from "react";
+import React, { useContext, useRef } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
 import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
@@ -8,7 +8,7 @@ import { WidgetViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
   widget: Decoration;
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
 };
 
 export function NativeWidgetView({ widget, getPos }: Props) {
@@ -35,8 +35,7 @@ export function NativeWidgetView({ widget, getPos }: Props) {
     const toDOM = (widget as any).type.toDOM as
       | HTMLElement
       | ((view: EditorView, getPos: () => number) => HTMLElement);
-    let dom =
-      typeof toDOM === "function" ? toDOM(view, () => getPos.current()) : toDOM;
+    let dom = typeof toDOM === "function" ? toDOM(view, getPos) : toDOM;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (!(widget as any).type.spec.raw) {
       if (dom.nodeType != 1) {
@@ -58,14 +57,13 @@ export function NativeWidgetView({ widget, getPos }: Props) {
     if (!viewDescRef.current) {
       viewDescRef.current = new WidgetViewDesc(
         parentRef.current,
-        () => getPos.current(),
+        getPos,
         widget,
         rootDomRef.current
       );
     } else {
       viewDescRef.current.parent = parentRef.current;
       viewDescRef.current.widget = widget;
-      viewDescRef.current.getPos = () => getPos.current();
       viewDescRef.current.dom = rootDomRef.current;
     }
     if (!siblingsRef.current.includes(viewDescRef.current)) {

--- a/src/components/NodeView.tsx
+++ b/src/components/NodeView.tsx
@@ -4,7 +4,7 @@ import {
   DecorationSource,
   NodeViewConstructor,
 } from "prosemirror-view";
-import React, { MutableRefObject, memo, useContext } from "react";
+import React, { memo, useContext } from "react";
 
 import { EditorContext } from "../contexts/EditorContext.js";
 
@@ -13,7 +13,7 @@ import { ReactNodeView } from "./ReactNodeView.js";
 
 type NodeViewProps = {
   outerDeco: readonly Decoration[];
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
   node: Node;
   innerDeco: DecorationSource;
 };

--- a/src/components/ReactNodeView.tsx
+++ b/src/components/ReactNodeView.tsx
@@ -2,7 +2,6 @@ import { DOMOutputSpec, Node } from "prosemirror-model";
 import { Decoration, DecorationSource } from "prosemirror-view";
 import React, {
   ComponentType,
-  MutableRefObject,
   cloneElement,
   memo,
   useContext,
@@ -23,7 +22,7 @@ import { OutputSpec } from "./OutputSpec.js";
 
 type Props = {
   outerDeco: readonly Decoration[];
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
   node: Node;
   innerDeco: DecorationSource;
 };
@@ -38,7 +37,6 @@ export const ReactNodeView = memo(function ReactNodeView({
   const domRef = useRef<HTMLElement | null>(null);
   const nodeDomRef = useRef<HTMLElement | null>(null);
   const contentDomRef = useRef<HTMLElement | null>(null);
-  const getPosFunc = useRef(() => getPos.current()).current;
 
   const { nodeViews } = useContext(NodeViewContext);
 
@@ -61,7 +59,7 @@ export const ReactNodeView = memo(function ReactNodeView({
     nodeViewDescRef,
   } = useNodeViewDescriptor(
     node,
-    () => getPos.current(),
+    getPos,
     domRef,
     nodeDomRef,
     innerDeco,
@@ -80,11 +78,11 @@ export const ReactNodeView = memo(function ReactNodeView({
   const nodeProps = useMemo(
     () => ({
       node: node,
-      getPos: getPosFunc,
+      getPos: getPos,
       decorations: outerDeco,
       innerDecorations: innerDeco,
     }),
-    [getPosFunc, innerDeco, node, outerDeco]
+    [getPos, innerDeco, node, outerDeco]
   );
 
   if (Component) {

--- a/src/components/SeparatorHackView.tsx
+++ b/src/components/SeparatorHackView.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, useContext, useRef, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 
 import { browser } from "../browser.js";
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
@@ -6,7 +6,7 @@ import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { TrailingHackViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
 };
 
 export function SeparatorHackView({ getPos }: Props) {
@@ -45,14 +45,13 @@ export function SeparatorHackView({ getPos }: Props) {
       viewDescRef.current = new TrailingHackViewDesc(
         parentRef.current,
         [],
-        () => getPos.current(),
+        getPos,
         ref.current,
         null
       );
     } else {
       viewDescRef.current.parent = parentRef.current;
       viewDescRef.current.dom = ref.current;
-      viewDescRef.current.getPos = () => getPos.current();
     }
     if (!siblingsRef.current.includes(viewDescRef.current)) {
       siblingsRef.current.push(viewDescRef.current);

--- a/src/components/TextNodeView.tsx
+++ b/src/components/TextNodeView.tsx
@@ -51,7 +51,7 @@ function shallowEqual(
 type Props = {
   view: AbstractEditorView;
   node: Node;
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
   siblingsRef: MutableRefObject<ViewDesc[]>;
   parentRef: MutableRefObject<ViewDesc | undefined>;
   decorations: readonly Decoration[];
@@ -76,7 +76,7 @@ export class TextNodeView extends Component<Props> {
 
       this.viewDescRef = new CompositionViewDesc(
         parentRef.current,
-        () => getPos.current(),
+        getPos,
         // These are just placeholders/dummies. We can't
         // actually find the correct DOM nodes from here,
         // so we let our parent do it.
@@ -99,7 +99,7 @@ export class TextNodeView extends Component<Props> {
       this.viewDescRef = new TextViewDesc(
         undefined,
         [],
-        () => getPos.current(),
+        getPos,
         node,
         decorations,
         DecorationSet.empty,
@@ -110,7 +110,6 @@ export class TextNodeView extends Component<Props> {
       this.viewDescRef.parent = parentRef.current;
       this.viewDescRef.children = [];
       this.viewDescRef.node = node;
-      this.viewDescRef.getPos = () => getPos.current();
       this.viewDescRef.outerDeco = decorations;
       this.viewDescRef.innerDeco = DecorationSet.empty;
       this.viewDescRef.dom = dom;
@@ -156,8 +155,8 @@ export class TextNodeView extends Component<Props> {
     // interrupt the composition
     if (
       view.composing &&
-      view.state.selection.from >= getPos.current() &&
-      view.state.selection.from <= getPos.current() + node.nodeSize
+      view.state.selection.from >= getPos() &&
+      view.state.selection.from <= getPos() + node.nodeSize
     ) {
       return this.renderRef;
     }

--- a/src/components/TrailingHackView.tsx
+++ b/src/components/TrailingHackView.tsx
@@ -1,11 +1,11 @@
-import React, { MutableRefObject, useContext, useRef } from "react";
+import React, { useContext, useRef } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
 import { useClientLayoutEffect } from "../hooks/useClientLayoutEffect.js";
 import { TrailingHackViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
 };
 
 export function TrailingHackView({ getPos }: Props) {
@@ -32,14 +32,13 @@ export function TrailingHackView({ getPos }: Props) {
       viewDescRef.current = new TrailingHackViewDesc(
         parentRef.current,
         [],
-        () => getPos.current(),
+        getPos,
         ref.current,
         null
       );
     } else {
       viewDescRef.current.parent = parentRef.current;
       viewDescRef.current.dom = ref.current;
-      viewDescRef.current.getPos = () => getPos.current();
     }
     if (!siblingsRef.current.includes(viewDescRef.current)) {
       siblingsRef.current.push(viewDescRef.current);

--- a/src/components/WidgetView.tsx
+++ b/src/components/WidgetView.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, useContext, useRef } from "react";
+import React, { useContext, useRef } from "react";
 
 import { ChildDescriptorsContext } from "../contexts/ChildDescriptorsContext.js";
 import { ReactWidgetDecoration } from "../decorations/ReactWidgetType.js";
@@ -7,13 +7,12 @@ import { WidgetViewDesc, sortViewDescs } from "../viewdesc.js";
 
 type Props = {
   widget: ReactWidgetDecoration;
-  getPos: MutableRefObject<() => number>;
+  getPos: () => number;
 };
 
 export function WidgetView({ widget, getPos }: Props) {
   const { siblingsRef, parentRef } = useContext(ChildDescriptorsContext);
   const viewDescRef = useRef<WidgetViewDesc | null>(null);
-  const getPosFunc = useRef(() => getPos.current()).current;
 
   const domRef = useRef<HTMLElement | null>(null);
 
@@ -34,14 +33,13 @@ export function WidgetView({ widget, getPos }: Props) {
     if (!viewDescRef.current) {
       viewDescRef.current = new WidgetViewDesc(
         parentRef.current,
-        () => getPos.current(),
+        getPos,
         widget,
         domRef.current
       );
     } else {
       viewDescRef.current.parent = parentRef.current;
       viewDescRef.current.widget = widget;
-      viewDescRef.current.getPos = () => getPos.current();
       viewDescRef.current.dom = domRef.current;
     }
     if (!siblingsRef.current.includes(viewDescRef.current)) {
@@ -57,7 +55,7 @@ export function WidgetView({ widget, getPos }: Props) {
       <Component
         ref={domRef}
         widget={widget}
-        getPos={getPosFunc}
+        getPos={getPos}
         contentEditable={false}
       />
     )

--- a/src/hooks/useNodeViewDescriptor.ts
+++ b/src/hooks/useNodeViewDescriptor.ts
@@ -116,7 +116,6 @@ export function useNodeViewDescriptor(
       nodeViewDescRef.current.parent = parentRef.current;
       nodeViewDescRef.current.children = childDescriptors.current;
       nodeViewDescRef.current.node = node;
-      nodeViewDescRef.current.getPos = getPos;
       nodeViewDescRef.current.outerDeco = outerDecorations;
       nodeViewDescRef.current.innerDeco = innerDecorations;
       nodeViewDescRef.current.dom = domRef?.current ?? nodeDomRef.current;


### PR DESCRIPTION
Rather than passing refs to position functions, construct stable functions as callbacks that close over offset refs.