### PR TITLE
Always set the doc node view's contentDOM to its dom

### DIFF
--- a/.yarn/versions/7fb36f6b.yml
+++ b/.yarn/versions/7fb36f6b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/DocNodeView.tsx
+++ b/src/components/DocNodeView.tsx
@@ -62,7 +62,8 @@ export const DocNodeView = memo(
       innerRef,
       innerRef,
       innerDeco,
-      outerDeco
+      outerDeco,
+      innerRef
     );
 
     const childContextValue = useMemo(

--- a/src/hooks/useNodeViewDescriptor.ts
+++ b/src/hooks/useNodeViewDescriptor.ts
@@ -105,7 +105,7 @@ export function useNodeViewDescriptor(
         outerDecorations,
         innerDecorations,
         domRef?.current ?? nodeDomRef.current,
-        firstChildDesc?.dom.parentElement ?? null,
+        contentDOMRef?.current ?? firstChildDesc?.dom.parentElement ?? null,
         nodeDomRef.current,
         (event) => !!stopEvent.current(event),
         () => selectNode.current(),


### PR DESCRIPTION
This is a bit of a workaround for the fact that our contentDOM detection is imperfect. Specifically, we will not find a contentDOM for a non-textblock that _can_ have children but does not currently. This isn't a very common situation, but it does happen if you have a schema that allows a doc with no children and have an empty doc. So to work around the most common version of this, we always set contentDOM to the dom, since that is guaranteed to be the case for the doc node view

Fixes #110 