### PR TITLE
Manually trigger release after pushing new tag

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,6 +51,7 @@ jobs:
 
     permissions:
       contents: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -66,6 +67,9 @@ jobs:
           PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
           ./scripts/if-version-change.sh git tag v${PACKAGE_VERSION}
           git push origin tag v${PACKAGE_VERSION}
+          gh workflow run release --ref v${PACKAGE_VERSION}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur. For more information, see [Use GITHUB_TOKEN for authentication in workflows](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).

You have to manually use the `gh` cli or REST API to trigger workflows from workflows. So this adds one last step to the bump-version job to manually trigger the release workflow after pushing the new tag