### PR TITLE
Allow all react/react-dom 19 versions

### DIFF
--- a/.yarn/versions/36df9694.yml
+++ b/.yarn/versions/36df9694.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -118,8 +118,8 @@
     "prosemirror-model": "^1.0.0",
     "prosemirror-state": "^1.0.0",
     "prosemirror-view": "1.39.2",
-    "react": ">=17 <=19.1.0",
-    "react-dom": ">=17 <=19.1.0",
+    "react": ">=17 <20",
+    "react-dom": ">=17 <20",
     "react-reconciler": ">=0.26.1 <=0.32.0"
   },
   "packageManager": "yarn@4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,8 +1503,8 @@ __metadata:
     prosemirror-model: ^1.0.0
     prosemirror-state: ^1.0.0
     prosemirror-view: 1.39.2
-    react: ">=17 <=19.1.0"
-    react-dom: ">=17 <=19.1.0"
+    react: ">=17 <20"
+    react-dom: ">=17 <20"
     react-reconciler: ">=0.26.1 <=0.32.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`react-reconciler@0.32.0` has `react@^19.1.0` as a peer dependency. This means it should be safe to install any React version higher than `19.1.0` as a peeer dependency, which (along with earlier react-reconciler versions) means it's safe for us to accept any minor/patch version of React 19.