### PR TITLE
fix: prevent errors when leaf nodes spread props to leaf components

### DIFF
--- a/.yarn/versions/974dcf8e.yml
+++ b/.yarn/versions/974dcf8e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/CustomNodeView.tsx
+++ b/src/components/CustomNodeView.tsx
@@ -216,6 +216,19 @@ export const CustomNodeView = memo(function CustomNodeView({
   }
   const { contentDOM } = customNodeViewRef.current;
   contentDomRef.current = contentDOM ?? null;
+
+  const children =
+    !node.isLeaf && contentDOM
+      ? createPortal(
+          <ChildNodeViews
+            getPos={getPos}
+            node={node}
+            innerDecorations={innerDeco}
+          />,
+          contentDOM
+        )
+      : null;
+
   const element = createElement(
     node.isInline ? "span" : "div",
     {
@@ -223,15 +236,7 @@ export const CustomNodeView = memo(function CustomNodeView({
       contentEditable: !!contentDOM,
       suppressContentEditableWarning: true,
     },
-    contentDOM &&
-      createPortal(
-        <ChildNodeViews
-          getPos={getPos}
-          node={node}
-          innerDecorations={innerDeco}
-        />,
-        contentDOM
-      )
+    children
   );
 
   const decoratedElement = cloneElement(

--- a/src/components/ReactNodeView.tsx
+++ b/src/components/ReactNodeView.tsx
@@ -85,25 +85,21 @@ export const ReactNodeView = memo(function ReactNodeView({
     [getPos, innerDeco, node, outerDeco]
   );
 
+  const children = !node.isLeaf ? (
+    <ChildNodeViews getPos={getPos} node={node} innerDecorations={innerDeco} />
+  ) : null;
+
   if (Component) {
     element = (
       <Component {...finalProps} ref={nodeDomRef} nodeProps={nodeProps}>
-        <ChildNodeViews
-          getPos={getPos}
-          node={node}
-          innerDecorations={innerDeco}
-        />
+        {children}
       </Component>
     );
   } else {
     if (outputSpec) {
       element = (
         <OutputSpec {...finalProps} ref={nodeDomRef} outputSpec={outputSpec}>
-          <ChildNodeViews
-            getPos={getPos}
-            node={node}
-            innerDecorations={innerDeco}
-          />
+          {children}
         </OutputSpec>
       );
     }


### PR DESCRIPTION
Leaf node views may render elements that cannot accept children. Prevent them from accidentally passing children to these elements when spreading their props onto their elements by not passing children to them.