### PR TITLE
fix: correct node view component props

### DIFF
--- a/.yarn/versions/ffc5c6ee.yml
+++ b/.yarn/versions/ffc5c6ee.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/NodeViewComponentProps.tsx
+++ b/src/components/NodeViewComponentProps.tsx
@@ -1,13 +1,12 @@
 import { Node } from "prosemirror-model";
 import { Decoration, DecorationSource } from "prosemirror-view";
-import { HTMLAttributes, LegacyRef, ReactNode } from "react";
+import { AllHTMLAttributes, LegacyRef } from "react";
 
-export type NodeViewComponentProps = {
+export interface NodeViewComponentProps extends AllHTMLAttributes<HTMLElement> {
   nodeProps: {
     decorations: readonly Decoration[];
     innerDecorations: DecorationSource;
     node: Node;
-    children?: ReactNode | ReactNode[];
     getPos: () => number;
   };
   // It's not really feasible to correctly type a Ref constraint,
@@ -16,4 +15,4 @@ export type NodeViewComponentProps = {
   // here, instead of a more useful type like HTMLElement | null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ref: LegacyRef<any>;
-} & HTMLAttributes<HTMLElement>;
+}


### PR DESCRIPTION
Improve the node view component props:

- Remove `children` prop from the `nodeProps` property because it is a top-level property.

- Extend from `AllHTMLAttributes` instead of `HTMLAttributes` to include attributes from all recognized HTML elements.