### PR TITLE
fix: clean up node view event handlers

### DIFF
--- a/.yarn/versions/3ce56d78.yml
+++ b/.yarn/versions/3ce56d78.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/contexts/StopEventContext.ts
+++ b/src/contexts/StopEventContext.ts
@@ -1,8 +1,6 @@
 import { createContext } from "react";
 
-type StopEventContextValue = (
-  stopEvent: (event: Event) => boolean | undefined
-) => void;
+type StopEventContextValue = (stopEvent: (event: Event) => boolean) => void;
 
 export const StopEventContext = createContext<StopEventContextValue>(
   null as unknown as StopEventContextValue

--- a/src/hooks/useIgnoreMutation.ts
+++ b/src/hooks/useIgnoreMutation.ts
@@ -12,6 +12,6 @@ export function useIgnoreMutation(
   const register = useContext(IgnoreMutationContext);
   const ignoreMutationMemo = useEditorEventCallback(ignoreMutation);
   useEditorEffect(() => {
-    register(ignoreMutationMemo);
+    return register(ignoreMutationMemo);
   }, [register, ignoreMutationMemo]);
 }

--- a/src/hooks/useNodeViewDescriptor.ts
+++ b/src/hooks/useNodeViewDescriptor.ts
@@ -36,10 +36,14 @@ export function useNodeViewDescriptor(
   const { view } = useContext(EditorContext);
   const [hasContentDOM, setHasContentDOM] = useState(true);
   const nodeViewDescRef = useRef<NodeViewDesc | undefined>();
-  const stopEvent = useRef<(event: Event) => boolean | undefined>(() => false);
+  const stopEvent = useRef<(event: Event) => boolean>(() => false);
   const setStopEvent = useCallback(
-    (newStopEvent: (event: Event) => boolean | undefined) => {
+    (newStopEvent: (event: Event) => boolean) => {
+      const oldStopEvent = stopEvent.current;
       stopEvent.current = newStopEvent;
+      return () => {
+        stopEvent.current = oldStopEvent;
+      };
     },
     []
   );
@@ -48,7 +52,11 @@ export function useNodeViewDescriptor(
   );
   const setIgnoreMutation = useCallback(
     (newIgnoreMutation: (mutation: ViewMutationRecord) => boolean) => {
+      const oldIgnoreMutation = ignoreMutation.current;
       ignoreMutation.current = newIgnoreMutation;
+      return () => {
+        ignoreMutation.current = oldIgnoreMutation;
+      };
     },
     []
   );
@@ -71,8 +79,14 @@ export function useNodeViewDescriptor(
   });
   const setSelectNode = useCallback(
     (newSelectNode: () => void, newDeselectNode: () => void) => {
+      const oldSelectNode = selectNode.current;
+      const oldDeselectNode = deselectNode.current;
       selectNode.current = newSelectNode;
       deselectNode.current = newDeselectNode;
+      return () => {
+        selectNode.current = oldSelectNode;
+        deselectNode.current = oldDeselectNode;
+      };
     },
     []
   );

--- a/src/hooks/useSelectNode.ts
+++ b/src/hooks/useSelectNode.ts
@@ -1,3 +1,4 @@
+import { EditorView } from "prosemirror-view";
 import { useContext } from "react";
 
 import { SelectNodeContext } from "../contexts/SelectNodeContext.js";
@@ -5,19 +6,18 @@ import { SelectNodeContext } from "../contexts/SelectNodeContext.js";
 import { useEditorEffect } from "./useEditorEffect.js";
 import { useEditorEventCallback } from "./useEditorEventCallback.js";
 
+function noop() {
+  // empty
+}
+
 export function useSelectNode(
-  selectNode: () => void,
-  deselectNode?: () => void
+  selectNode: (view: EditorView) => void,
+  deselectNode: (view: EditorView) => void = noop
 ) {
   const register = useContext(SelectNodeContext);
   const selectNodeMemo = useEditorEventCallback(selectNode);
-  const deselectNodeMemo = useEditorEventCallback(
-    deselectNode ??
-      (() => {
-        // empty
-      })
-  );
+  const deselectNodeMemo = useEditorEventCallback(deselectNode);
   return useEditorEffect(() => {
-    register(selectNodeMemo, deselectNodeMemo);
-  }, [deselectNodeMemo, register, selectNodeMemo]);
+    return register(selectNodeMemo, deselectNodeMemo);
+  }, [register, selectNodeMemo, deselectNodeMemo]);
 }

--- a/src/hooks/useStopEvent.ts
+++ b/src/hooks/useStopEvent.ts
@@ -12,6 +12,6 @@ export function useStopEvent(
   const register = useContext(StopEventContext);
   const stopEventMemo = useEditorEventCallback(stopEvent);
   useEditorEffect(() => {
-    register(stopEventMemo);
+    return register(stopEventMemo);
   }, [register, stopEventMemo]);
 }


### PR DESCRIPTION
When node view components unmount, clean up their event handlers.

Node view components may change due to reconfiguration or in-place node type changes, so ensure that these changes correctly set event handlers.