### PR TITLE
fix: prevent redraw on custom node view changes

### DIFF
--- a/.yarn/versions/778465c7.yml
+++ b/.yarn/versions/778465c7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -156,7 +156,8 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
 
     if (
       prevProps.state.plugins !== props.state.plugins ||
-      prevProps.plugins !== props.plugins
+      prevProps.plugins !== props.plugins ||
+      prevProps.nodeViews !== props.nodeViews
     ) {
       const nodeViews = buildNodeViews(this);
       if (changedNodeViews(this.nodeViews, nodeViews)) {


### PR DESCRIPTION
When the direct `nodeViews` prop of the editor view changes, rebuild the node views so that the base class from `prosemirror-view` does not.