### PR TITLE
fix: render fallbacks for custom node views

### DIFF
--- a/.yarn/versions/189b2a61.yml
+++ b/.yarn/versions/189b2a61.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch


### PR DESCRIPTION
When custom node view constructors fail to return a valid node view, render the default node view for the node.