### PR TITLE
fix: place image hack node before break hack node

### DIFF
--- a/.yarn/versions/033cc3e1.yml
+++ b/.yarn/versions/033cc3e1.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/ChildNodeViews.tsx
+++ b/src/components/ChildNodeViews.tsx
@@ -564,19 +564,19 @@ export const ChildNodeViews = memo(function ChildNodeViews({
       children.push(
         {
           type: "hack",
-          component: TrailingHackView,
-          marks: [],
-          offset: lastChild?.offset ?? 0,
-          index: (lastChild?.index ?? 0) + 1,
-          key: "trailing-hack-br",
-        },
-        {
-          type: "hack",
           component: SeparatorHackView,
           marks: [],
           offset: lastChild?.offset ?? 0,
           index: (lastChild?.index ?? 0) + 2,
           key: "trailing-hack-img",
+        },
+        {
+          type: "hack",
+          component: TrailingHackView,
+          marks: [],
+          offset: lastChild?.offset ?? 0,
+          index: (lastChild?.index ?? 0) + 1,
+          key: "trailing-hack-br",
         }
       );
     }


### PR DESCRIPTION
Restore the correct order of hack nodes after they got reordered in the changes from #108.

Fix #131.