### PR TITLE
Move `view.destroy()` call into layout effect body.

### DIFF
--- a/.yarn/versions/5904986f.yml
+++ b/.yarn/versions/5904986f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -117,18 +117,14 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
     return new StaticEditorView(directEditorProps);
   });
 
-  useClientLayoutEffect(() => {
-    return () => {
-      view.destroy();
-    };
-  }, [view]);
-
   // This rule is concerned about infinite updates due to the
   // call to setView. These calls are deliberately conditional,
   // so this is not a concern.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useClientLayoutEffect(() => {
     if (mount !== view.dom) {
+      view.destroy();
+
       if (mount) {
         const view = new ReactEditorView({ mount }, directEditorProps);
         view.dom.addEventListener("compositionend", forceUpdate);


### PR DESCRIPTION
In React 19, in StrictMode, in some circumstances, React will clean-up and re-run layout effects even if their dependencies have not changed and the component has not remounted.

This makes it unsafe to run `view.destroy()` in the clean-up for a layout effect that does not re-create the view, because the view can be destroyed even when it is not about to be updated to a new value, leaving a destroyed view in the document.

To resolve this, we move `view.destroy()` into the body of the layout effect that is actually responsible for creating the new view, and only when we're certain that we're about to create a new view.