### PR TITLE
fix: prevent the editor from destroying its content

### DIFF
--- a/.yarn/versions/ffb10f9c.yml
+++ b/.yarn/versions/ffb10f9c.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -222,6 +222,18 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     return undefined;
   }
 
+  destroy() {
+    // Prevent the base class from destroying the React-managed nodes.
+    // Restore them below after invoking the base class method.
+    const reactContent = [...this.dom.childNodes];
+
+    try {
+      super.destroy();
+    } finally {
+      this.dom.replaceChildren(...reactContent);
+    }
+  }
+
   /**
    * Commit effects by appling the pending props and state.
    *


### PR DESCRIPTION
Override `ReactEditorView#destroy()` to prevent the editor from removing all of its React-managed children.