### PR TITLE
Fix check for custom selectNode behavior

### DIFF
--- a/.yarn/versions/ccd64edf.yml
+++ b/.yarn/versions/ccd64edf.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/ReactNodeView.tsx
+++ b/src/components/ReactNodeView.tsx
@@ -42,7 +42,7 @@ export const ReactNodeView = memo(function ReactNodeView({
   node,
   innerDeco,
 }: Props) {
-  const [controlSelected, setControlSelected] = useState(false);
+  const [hasCustomSelectNode, setHasCustomSelectNode] = useState(false);
   const [selected, setSelected] = useState(false);
 
   const ref = useRef<HTMLElement>(null);
@@ -57,11 +57,11 @@ export const ReactNodeView = memo(function ReactNodeView({
     (selectHandler: SelectNode, deselectHandler: DeselectNode) => {
       selectNodeRef.current = selectHandler;
       deselectNodeRef.current = deselectHandler;
-      setControlSelected(true);
+      setHasCustomSelectNode(true);
       return () => {
         selectNodeRef.current = null;
         deselectNodeRef.current = null;
-        setControlSelected(false);
+        setHasCustomSelectNode(false);
       };
     },
     []
@@ -150,10 +150,10 @@ export const ReactNodeView = memo(function ReactNodeView({
           suppressContentEditableWarning: true,
         }
       : null),
-    ...(controlSelected && selected
+    ...(!hasCustomSelectNode && selected
       ? { className: "ProseMirror-selectednode" }
       : null),
-    ...((controlSelected && selected) || node.type.spec.draggable
+    ...((!hasCustomSelectNode && selected) || node.type.spec.draggable
       ? { draggable: true }
       : null),
     ref: innerRef,


### PR DESCRIPTION
The current behavior seems inverted — we will only use the default behavior if the consuming node view component _does_ use the `useSelectNode` hook. We instead want to only use the default behavior if the consuming node view _does not_ use the `useSelectNode` hook.

I updated the state name to hopefully make it a little clearer what it represents.

Fixes #142 