### PR TITLE
Abort onSelectionChange during compositions

### DIFF
--- a/.yarn/versions/1d53fa75.yml
+++ b/.yarn/versions/1d53fa75.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch


### PR DESCRIPTION
I haven't yet been able to refresh myself on how prosemirror-view natively avoids this situation, where onSelectionChange is triggered during a composition and results in flushing the ProseMirror selection back to the DOM (which then ends the composition), but this is the change that we lost when we moved from our custom SelectionDOMObserver back to ProseMirror's DOMObserver.

I think we should just put this back for now — if we want to try to better understand why this is necessary later, that's fine.