### PR TITLE
Add a destroyed property to ReactEditorView

### DIFF
--- a/.yarn/versions/6864e81c.yml
+++ b/.yarn/versions/6864e81c.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -138,7 +138,10 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
   }, [createEditorView, mount]);
 
   useClientLayoutEffect(() => {
-    if (view instanceof ReactEditorView) {
+    // Ensure that the EditorView hasn't been destroyed before
+    // running effects. Running effects will reattach selection
+    // change listeners if the EditorView has been destroyed.
+    if (view instanceof ReactEditorView && !view.isDestroyed) {
       view.commitPendingEffects();
     }
   });


### PR DESCRIPTION
When a render occurs that would destroy and recreate the EditorView, we still run a layout effect that attempts to commit pending effects for the now-destroyed layout effect. ProseMirror View, in this scenario, just re-attaches the DOM Observer and its selectionchange listener (but not the rest of the input event listeners). This results in two separae selectionchange handlers, one for a stale EditorView.

To prevent this, we track whether an EditorView has been destroyed, and abort from commitPendingEffects if it has.
