### PR TITLE
Update GitHub Workflow to use new Trusted Publishing flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,18 @@ jobs:
           generate_release_notes: true
 
   publish:
+    permissions:
+      id-token: write
+      contents: read
+
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
@@ -39,11 +43,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn
-
-      - name: Set NPM auth token
-        run: yarn config set npmAuthToken ${NPM_PUBLISH_TOKEN}
-        env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Publish to NPM
         run: yarn npm publish

--- a/.yarn/versions/88bf0496.yml
+++ b/.yarn/versions/88bf0496.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@handlewithcare/react-prosemirror"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "react-dom": ">=17 <20",
     "react-reconciler": ">=0.26.1 <=0.33.0"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.11.0",
   "engines": {
     "node": ">=16.9"
   },


### PR DESCRIPTION
I've also configured everything on the NPM side of things. This will use the new OIDC flow for authenticating with NPM, rather than our manually minted auth tokens!

https://docs.npmjs.com/trusted-publishers