### PR TITLE
fix: handle IME composition at GapCursor positions

### DIFF
--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -44,6 +44,7 @@ interface DOMObserver {
 }
 
 interface InputState {
+  composing: boolean;
   compositionID: number;
   compositionNodes: ViewDesc[];
   compositionPendingChanges: number;

--- a/src/components/__tests__/ProseMirror.composition.test.tsx
+++ b/src/components/__tests__/ProseMirror.composition.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { GapCursor, gapCursor } from "prosemirror-gapcursor";
 import { doc, em, p, strong } from "prosemirror-test-builder";
 // @ts-expect-error This is an internal export
 import { EditorView, __endComposition } from "prosemirror-view";
@@ -429,4 +430,64 @@ describe.skip("EditorView composition", () => {
 
   // it("can handle cross-paragraph compositions (keeping the last paragraph)", () =>
   //   crossParagraph(false));
+});
+
+describe("GapCursor composition", () => {
+  // In doc(p("foo"), p("bar")):
+  //   p("foo") occupies positions 0..4 (nodeSize 5)
+  //   position 5 is between the two paragraphs (parent = doc, not a textblock)
+  //   p("bar") occupies positions 5..9 (nodeSize 5)
+  const GAP_POS = 5;
+
+  it("compositionstart at a GapCursor position inserts a wrapping textblock", () => {
+    const { view } = tempEditor({
+      doc: doc(p("foo"), p("bar")),
+      plugins: [gapCursor()],
+    });
+
+    // Place a GapCursor between the two paragraphs.
+    view.dispatch(
+      view.state.tr.setSelection(new GapCursor(view.state.doc.resolve(GAP_POS)))
+    );
+    expect(view.state.selection).toBeInstanceOf(GapCursor);
+
+    view.dom.dispatchEvent(new CompositionEvent("compositionstart"));
+
+    // The fix inserts an empty paragraph at the gap position so the browser
+    // IME has a textblock to compose into.
+    expect(view.state.doc.childCount).toBe(3);
+    // The cursor must now be inside a textblock.
+    expect(view.state.selection.$from.parent.isTextblock).toBe(true);
+    // view.composing must be true — the handler did not bail out early.
+    expect(view.composing).toBe(true);
+  });
+
+  it("compositionend at a former GapCursor position inserts text exactly once", () => {
+    const { view } = tempEditor({
+      doc: doc(p("foo"), p("bar")),
+      plugins: [gapCursor()],
+    });
+
+    view.dispatch(
+      view.state.tr.setSelection(new GapCursor(view.state.doc.resolve(GAP_POS)))
+    );
+
+    view.dom.dispatchEvent(new CompositionEvent("compositionstart"));
+    // Sanity: paragraph was created, cursor is inside it.
+    expect(view.state.doc.childCount).toBe(3);
+
+    view.dom.dispatchEvent(
+      new CompositionEvent("compositionend", { data: "hi" })
+    );
+
+    // Collect all text in the document.
+    const texts: string[] = [];
+    view.state.doc.descendants((node) => {
+      if (node.isText && node.text) texts.push(node.text);
+    });
+    const fullText = texts.join("");
+
+    // "hi" must appear exactly once — not doubled.
+    expect(fullText).toBe("foohibar");
+  });
 });

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -1,11 +1,11 @@
-import { Mark } from "prosemirror-model";
-import { Plugin } from "prosemirror-state";
-import { Decoration, EditorView } from "prosemirror-view";
+import { Fragment, type Mark, Slice } from "prosemirror-model";
+import { Plugin, TextSelection } from "prosemirror-state";
+import type { Decoration, EditorView } from "prosemirror-view";
 
-import { ReactEditorView } from "../ReactEditorView.js";
+import type { ReactEditorView } from "../ReactEditorView.js";
 import { CursorWrapper } from "../components/CursorWrapper.js";
 import { widget } from "../decorations/ReactWidgetType.js";
-import { DOMNode } from "../dom.js";
+import type { DOMNode } from "../dom.js";
 
 function insertText(
   view: EditorView,
@@ -54,62 +54,109 @@ export function beforeInputPlugin(
 
           view.dispatch(state.tr.deleteSelection());
 
-          const $pos = state.selection.$from;
+          // Re-read state after dispatch — the stale `state` reference no
+          // longer reflects the current document after deleteSelection.
+          let currentState = view.state;
+          let $pos = currentState.selection.$from;
 
-          compositionMarks = state.storedMarks ?? $pos.marks();
+          // If the cursor is not in a textblock (e.g. a GapCursor between
+          // block nodes), insert a wrapping textblock so the browser has a
+          // text node to compose into. We must do this here — before
+          // taking the DOM snapshot — because without a snapshot the
+          // compositionend handler cannot restore the DOM prior to calling
+          // insertText, which leads to the composed text appearing twice.
+          if (!$pos.parent.isTextblock) {
+            const textNodeType = currentState.schema.nodes.text;
+            if (!textNodeType) return false;
+            const wrap = $pos.parent
+              .contentMatchAt($pos.index())
+              .findWrapping(textNodeType);
+            if (!wrap) return false;
+
+            let frag = Fragment.empty;
+            for (let i = wrap.length - 1; i >= 0; i--) {
+              const wrapType = wrap[i];
+              if (!wrapType) return false;
+              const node = wrapType.createAndFill(null, frag);
+              if (!node) return false;
+              frag = Fragment.from(node);
+            }
+
+            const tr = currentState.tr.replace(
+              $pos.pos,
+              $pos.pos,
+              new Slice(frag, 0, 0)
+            );
+            tr.setSelection(TextSelection.near(tr.doc.resolve($pos.pos + 1)));
+            view.dispatch(tr);
+            currentState = view.state;
+            $pos = currentState.selection.$from;
+            // Safety check: if still not in a textblock after wrapping, bail.
+            if (!$pos.parent.isTextblock) return false;
+          }
+
+          compositionMarks = currentState.storedMarks ?? $pos.marks();
           if (compositionMarks) {
             setCursorWrapper(
-              widget(state.selection.from, CursorWrapper, {
+              widget(currentState.selection.from, CursorWrapper, {
                 key: "cursor-wrapper",
                 marks: compositionMarks,
               })
             );
           }
 
-          // Snapshot the siblings of the node that contains the
-          // current cursor. We'll restore this later, so that React
-          // doesn't panic about unknown DOM nodes.
+          // Snapshot the siblings of the node that contains the current
+          // cursor. We'll restore this later, so that React doesn't panic
+          // about unknown DOM nodes introduced by the browser's IME.
           const { node: parent } = view.domAtPos($pos.pos);
           precompositionSnapshot = [];
           for (const node of parent.childNodes) {
             precompositionSnapshot.push(node);
           }
 
-          // @ts-expect-error Internal property - input
-          view.input.composing = true;
+          (view as ReactEditorView).input.composing = true;
           return true;
         },
         compositionupdate() {
           return true;
         },
         compositionend(view, event) {
-          // @ts-expect-error Internal property - input
-          view.input.composing = false;
+          (view as ReactEditorView).input.composing = false;
 
           const { state } = view;
           const { node: parent } = view.domAtPos(state.selection.from);
 
           if (precompositionSnapshot) {
-            // Restore the snapshot of the parent node's children
-            // from before the composition started. This gives us a
-            // clean slate from which to dispatch our transaction
-            // and trigger a React update.
-            precompositionSnapshot.forEach((prevNode, i) => {
-              if (parent.childNodes.length <= i) {
-                parent.appendChild(prevNode);
-                return;
-              }
-              parent.replaceChild(prevNode, parent.childNodes.item(i));
-            });
+            // Restore the snapshot of the parent node's children from before
+            // the composition started. This gives us a clean slate from
+            // which to dispatch our transaction and trigger a React update.
+            //
+            // Wrapped in try/catch because structural edits dispatched during
+            // compositionstart (e.g. inserting a wrapping textblock at a
+            // gap-cursor position) may have moved or removed the snapshotted
+            // nodes, making replaceChild throw. In that case we skip
+            // restoration and let React reconcile the DOM on the next render.
+            try {
+              precompositionSnapshot.forEach((prevNode, i) => {
+                if (parent.childNodes.length <= i) {
+                  parent.appendChild(prevNode);
+                  return;
+                }
+                parent.replaceChild(prevNode, parent.childNodes.item(i));
+              });
 
-            if (parent.childNodes.length > precompositionSnapshot.length) {
-              for (
-                let i = precompositionSnapshot.length;
-                i < parent.childNodes.length;
-                i++
-              ) {
-                parent.removeChild(parent.childNodes.item(i));
+              if (parent.childNodes.length > precompositionSnapshot.length) {
+                for (
+                  let i = precompositionSnapshot.length;
+                  i < parent.childNodes.length;
+                  i++
+                ) {
+                  parent.removeChild(parent.childNodes.item(i));
+                }
               }
+            } catch (_) {
+              // DOM restoration failed — structural changes during composition
+              // made the snapshot stale. React will reconcile on next render.
             }
           }
 


### PR DESCRIPTION
> [!NOTE]
> This fix (code, tests, and PR description) was generated with the assistance of an LLM (Claude). I have reviewed and validated the changes.

## Problem

When a user triggers an IME composition (e.g. typing Chinese/Japanese/Korean) while the cursor is at a [**GapCursor**](https://github.com/ProseMirror/prosemirror-gapcursor) position (between block nodes, not inside a textblock), the composed text appears **twice**.

Root cause: the `compositionstart` handler in `beforeInputPlugin` assumes the cursor is always inside a textblock. At a GapCursor position, `$pos.parent` is the document (or a non-textblock wrapper), so:

1. No wrapping textblock is created for the browser's IME to compose into.
2. No DOM snapshot (`precompositionSnapshot`) is taken, because `view.domAtPos()` returns a non-textblock parent.
3. `composing` is never set to `true`.

Without a snapshot, the `compositionend` handler skips DOM restoration and calls `insertText()` on top of text the browser already wrote into the DOM, resulting in doubled text.

There is also a secondary stale-state bug: after `view.dispatch(state.tr.deleteSelection())`, the handler continues reading `state.selection.$from` from the **pre-dispatch** `state` reference, which no longer reflects the current document.

## Fix

Three changes in `src/plugins/beforeInputPlugin.ts`:

### 1. Re-read `view.state` after `deleteSelection()` dispatch

```ts
view.dispatch(state.tr.deleteSelection());
let currentState = view.state; // re-read after dispatch
let $pos = currentState.selection.$from;
```

### 2. Insert a wrapping textblock at GapCursor positions

When `$pos.parent.isTextblock` is false, use `contentMatchAt().findWrapping(schema.nodes.text)` to determine the correct wrapper node type(s) — this is schema-agnostic and works with any ProseMirror schema. The wrapping textblock is inserted, the selection is moved inside it, and then the normal DOM snapshot is taken.

### 3. Wrap DOM restoration in try/catch

The structural edit (inserting a textblock) during `compositionstart` may move or remove the nodes captured in the snapshot. When `compositionend` tries to restore these nodes, `replaceChild` can throw. The try/catch allows React to reconcile the DOM on the next render instead of crashing.

### Additional: add `composing` to `InputState` interface

Added `composing: boolean` to the `InputState` interface in `ReactEditorView.ts`, replacing the two `@ts-expect-error` suppressions with proper type-safe casts.

## Tests

Added a new `describe("GapCursor composition")` block in `ProseMirror.composition.test.tsx` with two tests:

- **compositionstart at a GapCursor position inserts a wrapping textblock** — verifies that a new paragraph is created, the cursor moves inside it, and `view.composing` is set to `true`.
- **compositionend at a former GapCursor position inserts text exactly once** — verifies that after a full compositionstart/compositionend cycle, the composed text appears exactly once in the document (not doubled).

Both tests run in jsdom via `yarn test:unit`. The existing browser-level WDIO tests (`yarn test:wdio`) are not affected by this change but are currently broken in the local environment due to a pre-existing Firefox/WebDriver BiDi protocol mismatch unrelated to this PR.

## Files changed

- `src/plugins/beforeInputPlugin.ts` — main fix (compositionstart/compositionend handlers)
- `src/ReactEditorView.ts` — added `composing: boolean` to `InputState` interface
- `src/components/__tests__/ProseMirror.composition.test.tsx` — added 2 new tests
