### PR TITLE
Always sort children after rendering, in case children were reordered but didn't rerender

### DIFF
--- a/.yarn/versions/09969fd4.yml
+++ b/.yarn/versions/09969fd4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useNodeViewDescription.ts
+++ b/src/hooks/useNodeViewDescription.ts
@@ -175,7 +175,23 @@ export function useNodeViewDescription(
     if (!siblings.includes(viewDesc)) {
       siblings.push(viewDesc);
     }
+
+    // In strict/concurrent mode, a node can sometimes re-render
+    // entirely on its own, without even its parent re-rendering.
+    // In this case, we will have added our view descriptions to
+    // our parent's children, but our parent has no opportunity
+    // to sort its children, because it never renders. So
+    // we always sort our siblings, too.
     siblings.sort(sortViewDescs);
+
+    // If a child updates, usually it will re-render and sort
+    // our children for us. But it's possible to reorder
+    // child nodes without changing their keys or node
+    // instances, in which case our children _won't_
+    // rerender. As a fallback, we do one last pass through
+    // our own child view descriptions and make sure
+    // they're ordered. This should be a cheap no-op in most cases.
+    children.sort(sortViewDescs);
 
     for (const child of children) {
       child.parent = viewDesc;


### PR DESCRIPTION
The reorderSiblings command will maintain the current node references and keys (and therefore DOM nodes) after the transaction. This means that none of the children re-render.

Since they don't re-render, they don't run their layout effects, which means they don't sort their sibling view descriptions.

This means that the parent view description has a stale child order, which breaks all sorts of things.

This change, as a fallback, has node views always sort their child node view descriptions after rendering.