### PR TITLE
Fix separator hack rendering

### DIFF
--- a/.yarn/versions/c2ddccb8.yml
+++ b/.yarn/versions/c2ddccb8.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/SeparatorHackView.tsx
+++ b/src/components/SeparatorHackView.tsx
@@ -30,7 +30,10 @@ export function SeparatorHackView({ getPos }: Props) {
   // we call setShouldRender conditionally
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useClientLayoutEffect(() => {
-    const lastSibling = siblingsRef.current[siblingsRef.current.length - 1];
+    const nonHackSiblings = siblingsRef.current.filter(
+      (viewdesc) => !(viewdesc instanceof TrailingHackViewDesc)
+    );
+    const lastSibling = nonHackSiblings[nonHackSiblings.length - 1];
     if (
       (browser.safari || browser.chrome) &&
       (lastSibling?.dom as HTMLElement)?.contentEditable == "false"
@@ -60,6 +63,6 @@ export function SeparatorHackView({ getPos }: Props) {
   });
 
   return shouldRender ? (
-    <img ref={ref} className="ProseMirror-separator" />
+    <img ref={ref} className="ProseMirror-separator" alt="" />
   ) : null;
 }

--- a/src/components/__tests__/ProseMirror.draw.test.tsx
+++ b/src/components/__tests__/ProseMirror.draw.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "prosemirror-test-builder";
 import React, { forwardRef } from "react";
 
+import { browser } from "../../browser.js";
 import { tempEditor } from "../../testing/editorViewTestHelpers.js";
 import { NodeViewComponentProps } from "../nodes/NodeViewComponentProps.js";
 
@@ -307,5 +308,63 @@ describe("EditorView draw", () => {
     });
 
     expect(view.dom.textContent).toBe("Some bold text");
+  });
+
+  it("renders a separator hack after non-editable nodes", () => {
+    if (!browser.chrome) return;
+
+    const testSchema = new Schema<"doc" | "paragraph" | "mention">({
+      nodes: schema.spec.nodes.addToEnd("mention", {
+        group: "inline",
+        inline: true,
+        atom: true,
+        selectable: true,
+        attrs: {
+          id: { default: null },
+          label: { default: null },
+        },
+        parseDOM: [
+          {
+            tag: 'span.mention[data-mention="true"]',
+            getAttrs(dom) {
+              const el = dom as HTMLElement;
+              return {
+                id: el.getAttribute("data-id"),
+                label: el.getAttribute("data-label"),
+              };
+            },
+          },
+        ],
+        toDOM(node) {
+          return [
+            "span",
+            {
+              class: "mention",
+              "data-mention": "true",
+              "data-id": node.attrs.id,
+              "data-label": node.attrs.label,
+            },
+            `@${node.attrs.label ?? ""}`,
+          ];
+        },
+      }),
+    });
+
+    const { doc, paragraph, mention } = builders(testSchema);
+
+    const { view } = tempEditor({
+      doc: doc(paragraph(mention({ id: "u1", label: "alice" }))),
+    });
+
+    const p = view.dom.firstElementChild;
+    const mentionDom = p?.firstElementChild;
+    const separatorHack = mentionDom?.nextElementSibling;
+    const trailingHack = separatorHack?.nextElementSibling;
+
+    expect(mentionDom?.textContent).toBe("@alice");
+    expect(separatorHack?.tagName).toBe("IMG");
+    expect(separatorHack?.className).toBe("ProseMirror-separator");
+    expect(trailingHack?.tagName).toBe("BR");
+    expect(trailingHack?.className).toBe("ProseMirror-trailingBreak");
   });
 });

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -66,23 +66,23 @@ export const config: WebdriverIO.Config = {
   // https://saucelabs.com/platform/platform-configurator
   //
   capabilities: [
-    // {
-    //   browserName: "chrome",
-    //   "wdio:exclude": mobileSpecs,
-    // },
+    {
+      browserName: "chrome",
+      "wdio:exclude": mobileSpecs,
+    },
     {
       browserName: "firefox",
       "wdio:exclude": mobileSpecs,
     },
-    // {
-    //   browserName: "chrome",
-    //   "wdio:specs": mobileSpecs,
-    //   "goog:chromeOptions": {
-    //     mobileEmulation: {
-    //       deviceName: "Pixel 7",
-    //     },
-    //   },
-    // },
+    {
+      browserName: "chrome",
+      "wdio:specs": mobileSpecs,
+      "goog:chromeOptions": {
+        mobileEmulation: {
+          deviceName: "Pixel 7",
+        },
+      },
+    },
   ],
 
   //


### PR DESCRIPTION
Our check for lastSibling in SeparatorHackView's contentEditable attribute always returned false, because the last sibling is always the TrailingHackView. So now we look for the last sibling that is not a TrailingHackView, which gives us the correct behavior of rendering the SeparatorHackView after the last inline node if it is not contentEditable.

Fixes #208 