### PR TITLE
Add isText method to ViewDesc

### DIFF
--- a/.yarn/versions/5224ab66.yml
+++ b/.yarn/versions/5224ab66.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -660,6 +660,10 @@ export class ViewDesc {
   get ignoreForSelection() {
     return false;
   }
+
+  isText(_text: string) {
+    return false;
+  }
 }
 
 // A widget desc represents a widget decoration, which is a DOM node
@@ -1018,6 +1022,10 @@ export class TextViewDesc extends NodeViewDesc {
 
   get domAtom() {
     return false;
+  }
+
+  isText(text: string) {
+    return this.node.text == text;
   }
 }
 


### PR DESCRIPTION
When we first wrote ReactEditorView, we overrode view.update to be a no-op, so viewdec.isText (which is only ever called if view.update is called during a composition) was never called.

But then we refactored ReactEditorView to have less forked code, and we never added in ViewDesc.isText. So if you trigger an update during a composition now, we actually throw an error trying to call an undefined method. 

This change just adds the isText() implementation from prosemirror-view.