### PR TITLE
Fix selections reverting when selecting quickly

### DIFF
--- a/.yarn/versions/6d115979.yml
+++ b/.yarn/versions/6d115979.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -35,12 +35,23 @@ function changedNodeViews(a: NodeViewSet, b: NodeViewSet) {
   return nA != nB;
 }
 
+interface SelectionState {
+  anchorNode: Node | null;
+  anchorOffset: number;
+  focusNode: Node | null;
+  focusOffset: number;
+  eq(domSel: DOMSelectionRange): boolean;
+  set(domSel: DOMSelectionRange): void;
+}
+
 interface DOMObserver {
   observer: MutationObserver | null;
   queue: MutationRecord[];
+  currentSelection: SelectionState;
   start(): void;
   stop(): void;
   onSelectionChange(): void;
+  setCurSelection(): void;
 }
 
 interface InputState {
@@ -63,7 +74,7 @@ interface InputState {
   mouseDown: {
     allowDefault: boolean;
     delayedSelectionSync: boolean;
-  };
+  } | null;
 }
 
 /**
@@ -282,7 +293,39 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     // node view selection callbacks.
     this.docView.markDirty(-1, -1);
 
-    super.update(this.nextProps);
+    // If an update comes in after a DOM selection change but before the corresponding
+    // "selectionchange" event, don't call selectionToDOM yet.
+    //
+    // prosemirror-view already guards against this in updateStateInner for drag events.
+    // We want to restore those guard conditions when the browser's selection has
+    // advanced past what view.state.selection knows about
+    const domSel = this.domSelectionRange();
+
+    const selectionBehindDOM =
+      !this.composing &&
+      !this.input.mouseDown &&
+      !this.domObserver.currentSelection.eq(domSel);
+
+    if (selectionBehindDOM) {
+      const savedFocusNode = this.domObserver.currentSelection.focusNode;
+      const savedFocusOffset = this.domObserver.currentSelection.focusOffset;
+
+      this.domObserver.setCurSelection();
+      this.input.mouseDown = {
+        allowDefault: false,
+        delayedSelectionSync: false,
+      };
+
+      try {
+        super.update(this.nextProps);
+      } finally {
+        this.input.mouseDown = null;
+        this.domObserver.currentSelection.focusNode = savedFocusNode;
+        this.domObserver.currentSelection.focusOffset = savedFocusOffset;
+      }
+    } else {
+      super.update(this.nextProps);
+    }
 
     // Store the new previous state.
     this.prevState = this.state;

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -35,19 +35,9 @@ function changedNodeViews(a: NodeViewSet, b: NodeViewSet) {
   return nA != nB;
 }
 
-interface SelectionState {
-  anchorNode: Node | null;
-  anchorOffset: number;
-  focusNode: Node | null;
-  focusOffset: number;
-  eq(domSel: DOMSelectionRange): boolean;
-  set(domSel: DOMSelectionRange): void;
-}
-
 interface DOMObserver {
   observer: MutationObserver | null;
   queue: MutationRecord[];
-  currentSelection: SelectionState;
   start(): void;
   stop(): void;
   onSelectionChange(): void;

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -293,38 +293,23 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     // node view selection callbacks.
     this.docView.markDirty(-1, -1);
 
-    // If an update comes in after a DOM selection change but before the corresponding
-    // "selectionchange" event, don't call selectionToDOM yet.
-    //
-    // prosemirror-view already guards against this in updateStateInner for drag events.
-    // We want to restore those guard conditions when the browser's selection has
-    // advanced past what view.state.selection knows about
-    const domSel = this.domSelectionRange();
-
-    const selectionBehindDOM =
-      !this.composing &&
-      !this.input.mouseDown &&
-      !this.domObserver.currentSelection.eq(domSel);
-
-    if (selectionBehindDOM) {
-      const savedFocusNode = this.domObserver.currentSelection.focusNode;
-      const savedFocusOffset = this.domObserver.currentSelection.focusOffset;
-
+    const selectionChanged = !this.state.selection.eq(this.prevState.selection);
+    if (selectionChanged) {
+      super.update(this.nextProps);
+    } else {
+      // If the selection hasn't changed between renders, force prosemirror-view to
+      // skip the selectionToDOM call. If a render happens after a DOM selection change
+      // but before the "selectionchange" event fired, calling selectionToDOM will cause
+      // the selection to be reset its the previous position.
       this.domObserver.setCurSelection();
       this.input.mouseDown = {
         allowDefault: false,
         delayedSelectionSync: false,
       };
 
-      try {
-        super.update(this.nextProps);
-      } finally {
-        this.input.mouseDown = null;
-        this.domObserver.currentSelection.focusNode = savedFocusNode;
-        this.domObserver.currentSelection.focusOffset = savedFocusOffset;
-      }
-    } else {
       super.update(this.nextProps);
+
+      this.input.mouseDown = null;
     }
 
     // Store the new previous state.


### PR DESCRIPTION
When you select text very quickly, the selection can sometimes end up "reverting" partially, meaning the last several characters you selected get unselected after you release. 

This happens when an update arrives after a DOM selection change but before the corresponding "selectionchange" has fired.  In this case,`selectionToDOM` gets called with an out of date selection, which "reverts" the latest DOM selection change. prosemirror-view guards against this for drag events already:

```
            // Work around for an issue where an update arriving right between
            // a DOM selection change and the "selectionchange" event for it
            // can cause a spurious DOM selection update, disrupting mouse
            // drag selection.
            if (forceSelUpdate ||
                !(this.input.mouseDown && this.domObserver.currentSelection.eq(this.domSelectionRange()) &&
                    anchorInRightPlace(this))) {
                selectionToDOM(this, forceSelUpdate);
            }
```

This PR restores these guard conditions so we can `update` without calling `selectionToDOM` if the selection hasn't actually changed in a render