### PR TITLE
Don't set stored marks unconditionally on delete

### DIFF
--- a/.yarn/versions/f9d5bdcb.yml
+++ b/.yarn/versions/f9d5bdcb.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -176,7 +176,7 @@ export function beforeInputPlugin() {
 
           handleGapCursorComposition(view);
 
-          if (storedMarks) {
+          if (storedMarks != null) {
             view.dispatch(
               view.state.tr.setMeta(reactKeysPluginKey, {
                 cursorWrapper: widget(
@@ -340,11 +340,13 @@ export function beforeInputPlugin() {
                 const end = view.posAtDOM(range.endContainer, range.endOffset);
                 const { doc } = view.state;
 
-                const storedMarks = doc
-                  .resolve(start)
-                  .marksAcross(doc.resolve(end));
+                const marks = doc.resolve(start).marksAcross(doc.resolve(end));
 
-                tr.delete(start, end).setStoredMarks(storedMarks);
+                tr.delete(start, end);
+
+                if (marks) {
+                  tr.ensureMarks(marks);
+                }
               }
               view.dispatch(tr);
               break;


### PR DESCRIPTION
This is what was causing the Chrome/Korean bug, and why you specifically needed to delete to trigger it. We were using `tr.setStoredMarks`, which is _not_ what ProseMirror View does. ProseMirror View uses `ensureMarks`:

```ts
      let tr = mkTr(view.state.tr.delete(chFrom, chTo))
      let marks = doc.resolve(change.start).marksAcross(doc.resolve(change.endA))
      if (marks) tr.ensureMarks(marks)
```