### PR TITLE
fix accented characters via long press

### DIFF
--- a/.yarn/versions/4e072970.yml
+++ b/.yarn/versions/4e072970.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -319,7 +319,10 @@ export function beforeInputPlugin() {
             }
             case "insertText": {
               const ranges = event.getTargetRanges();
-              if (ranges.length <= 1 && ranges[0] && ranges[0].collapsed) {
+              if (
+                ranges.length === 0 ||
+                (ranges.length === 1 && ranges[0] && ranges[0].collapsed)
+              ) {
                 insertText(view, event.data);
               } else {
                 for (const range of ranges) {

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -319,7 +319,7 @@ export function beforeInputPlugin() {
             }
             case "insertText": {
               const ranges = event.getTargetRanges();
-              if (ranges.length === 0 || (ranges[0] && ranges[0].collapsed)) {
+              if (ranges.length <= 1 && ranges[0] && ranges[0].collapsed) {
                 insertText(view, event.data);
               } else {
                 for (const range of ranges) {

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -318,7 +318,24 @@ export function beforeInputPlugin() {
               break;
             }
             case "insertText": {
-              insertText(view, event.data);
+              const ranges = event.getTargetRanges();
+              if (ranges.length === 0 || (ranges[0] && ranges[0].collapsed)) {
+                insertText(view, event.data);
+              } else {
+                for (const range of ranges) {
+                  const from = view.posAtDOM(
+                    range.startContainer,
+                    range.startOffset,
+                    1
+                  );
+                  const to = view.posAtDOM(
+                    range.endContainer,
+                    range.endOffset,
+                    1
+                  );
+                  insertText(view, event.data, { from, to });
+                }
+              }
               break;
             }
             case "deleteWordBackward":


### PR DESCRIPTION
When you type "é" by holding down "e" to get the accent options menu and selecting an option, the browser doesn't emit any composition events. Instead, Chrome/Firefox just emit one `insertText` for the "e" and another `insertText` for the "é". In order to properly replace the initial "e" when the "é" comes in, we need `insertText` to also `getTargetRanges`.