### PR TITLE
Skip selectionToDOM if selection hasn't changed

### DIFF
--- a/.yarn/versions/2cdc8e8d.yml
+++ b/.yarn/versions/2cdc8e8d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -293,7 +293,28 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     // node view selection callbacks.
     this.docView.markDirty(-1, -1);
 
-    super.update(this.nextProps);
+    const nextSelection = this.nextProps.state.selection;
+    const currentSelection = this.prevState.selection;
+
+    const selectionChanged = !nextSelection.eq(currentSelection);
+
+    if (selectionChanged) {
+      super.update(this.nextProps);
+    } else {
+      // If the selection hasn't changed between renders, force prosemirror-view to
+      // skip the selectionToDOM call. If a render happens after a DOM selection change
+      // but before the "selectionchange" event fired, calling selectionToDOM will cause
+      // the selection to be reset its the previous position.
+      this.domObserver.setCurSelection();
+      this.input.mouseDown = {
+        allowDefault: false,
+        delayedSelectionSync: false,
+      };
+
+      super.update(this.nextProps);
+
+      this.input.mouseDown = null;
+    }
 
     // Store the new previous state.
     this.prevState = this.state;


### PR DESCRIPTION
When you select text very quickly, the selection can sometimes end up "reverting" partially, meaning the last several characters you selected get unselected after you release.

This happens when an update arrives after a DOM selection change but before the corresponding "selectionchange" has fired. In this case,selectionToDOM gets called with an out of date selection, which "reverts" the latest DOM selection change. prosemirror-view guards against this for drag events already:

            // Work around for an issue where an update arriving right between
            // a DOM selection change and the "selectionchange" event for it
            // can cause a spurious DOM selection update, disrupting mouse
            // drag selection.
            if (forceSelUpdate ||
                !(this.input.mouseDown && this.domObserver.currentSelection.eq(this.domSelectionRange()) &&
                    anchorInRightPlace(this))) {
                selectionToDOM(this, forceSelUpdate);
            }
This PR restores these guard conditions so we can update without calling selectionToDOM if the selection hasn't actually changed in a render

A previous version of this fix wasn't correctly comparing the next selection to the current selection, which was resulting in an incorrect `selectionChanged` value!