### PR TITLE
Skip selectionToDOM while composing too

### DIFF
--- a/.yarn/versions/4e1f51b7.yml
+++ b/.yarn/versions/4e1f51b7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -297,14 +297,13 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     const currentSelection = this.prevState.selection;
 
     const selectionChanged = !nextSelection.eq(currentSelection);
-
-    if (selectionChanged) {
+    if (selectionChanged && !this.composing) {
       super.update(this.nextProps);
     } else {
-      // If the selection hasn't changed between renders, force prosemirror-view to
-      // skip the selectionToDOM call. If a render happens after a DOM selection change
-      // but before the "selectionchange" event fired, calling selectionToDOM will cause
-      // the selection to be reset its the previous position.
+      // If the selection hasn't changed between renders or we're composing, force
+      // prosemirror-view to skip the selectionToDOM call. If a render happens after a DOM
+      // selection change but before the "selectionchange" event fired, calling
+      // selectionToDOM will cause the selection to be reset to its previous position.
       this.domObserver.setCurSelection();
       this.input.mouseDown = {
         allowDefault: false,


### PR DESCRIPTION
We should also force prosemirror-view to skip the selectionToDOM call if we're composing, since changing the selection can cancel the composition