### PR TITLE
Safari IME composition fixes

### DIFF
--- a/.yarn/versions/33a4678b.yml
+++ b/.yarn/versions/33a4678b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -300,7 +300,7 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     if (selectionChanged) {
       super.update(this.nextProps);
     } else {
-      // If the selection hasn't changed between renders or we're composing, force
+      // If the selection hasn't changed between renders, force
       // prosemirror-view to skip the selectionToDOM call. If a render happens after a DOM
       // selection change but before the "selectionchange" event fired, calling
       // selectionToDOM will cause the selection to be reset to its previous position.

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -297,7 +297,7 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     const currentSelection = this.prevState.selection;
 
     const selectionChanged = !nextSelection.eq(currentSelection);
-    if (selectionChanged && !this.composing) {
+    if (selectionChanged) {
       super.update(this.nextProps);
     } else {
       // If the selection hasn't changed between renders or we're composing, force

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -3,6 +3,7 @@ import { Plugin, TextSelection } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
 import { ReactEditorView } from "../ReactEditorView.js";
+import { browser } from "../browser.js";
 import { CursorWrapper } from "../components/CursorWrapper.js";
 import { widget } from "../decorations/ReactWidgetType.js";
 import { DOMNode } from "../dom.js";
@@ -175,8 +176,14 @@ export function beforeInputPlugin() {
           );
 
           handleGapCursorComposition(view);
+          const { selection } = view.state;
 
-          if (storedMarks != null) {
+          const tr = view.state.tr.delete(selection.from, selection.to);
+          const $from = tr.doc.resolve(tr.mapping.map(selection.from));
+          const isEmptyTextblock =
+            $from.parent.isTextblock && $from.parent.childCount === 0;
+
+          if (storedMarks != null || (browser.safari && isEmptyTextblock)) {
             view.dispatch(
               view.state.tr.setMeta(reactKeysPluginKey, {
                 cursorWrapper: widget(
@@ -184,7 +191,7 @@ export function beforeInputPlugin() {
                   CursorWrapper,
                   {
                     key: "cursor-wrapper",
-                    marks: storedMarks,
+                    ...(storedMarks !== null && { marks: storedMarks }),
                     side: 0,
                     raw: true,
                   }

--- a/src/plugins/beforeInputPlugin.ts
+++ b/src/plugins/beforeInputPlugin.ts
@@ -143,6 +143,16 @@ export function beforeInputPlugin() {
     view.input.compositionID++;
   }
 
+  function teardownCompositionAndUnfreeze(view: ReactEditorView, event: Event) {
+    teardownComposition(view, event.timeStamp);
+    view.dispatch(
+      view.state.tr.setMeta(reactKeysPluginKey, {
+        cursorWrapper: null,
+        freezeFrom: null,
+      })
+    );
+  }
+
   return new Plugin({
     view() {
       return {
@@ -260,18 +270,31 @@ export function beforeInputPlugin() {
         },
         compositionend(view, event) {
           if (!(view instanceof ReactEditorView)) return false;
-
           if (!view.composing) return false;
 
-          teardownComposition(view, event.timeStamp);
-          view.dispatch(
-            view.state.tr.setMeta(reactKeysPluginKey, {
-              cursorWrapper: null,
-              freezeFrom: null,
-            })
-          );
-
+          teardownCompositionAndUnfreeze(view, event);
           return true;
+        },
+        contextmenu(view, event) {
+          if (!(view instanceof ReactEditorView)) return false;
+          if (!view.composing) return false;
+
+          teardownCompositionAndUnfreeze(view, event);
+          return false;
+        },
+        mousedown(view, event) {
+          if (!(view instanceof ReactEditorView)) return false;
+          if (!view.composing) return false;
+
+          teardownCompositionAndUnfreeze(view, event);
+          return false;
+        },
+        touchstart(view, event) {
+          if (!(view instanceof ReactEditorView)) return false;
+          if (!view.composing) return false;
+
+          teardownCompositionAndUnfreeze(view, event);
+          return false;
         },
         beforeinput(view, event) {
           if (event.inputType !== "insertFromComposition") {

--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -481,6 +481,7 @@ export class ViewDesc {
     view: ReactEditorView,
     force = false
   ): void {
+    if (view.composing) return;
     // If the selection falls entirely in a child, give it to that child
     const from = Math.min(anchor, head),
       to = Math.max(anchor, head);


### PR DESCRIPTION
Adds a few Safari IME composition related fixes:

- Add event handlers for mousedown, contextmenu and touchstart - prosemirror-view clears the composition on these events, and we need to teardownComposition before prosemirror view does that
- Always render a cursor wrapper in Safari when starting a composition in a new text node. Safari can do some unexpected things to the DOM when the parent of the composition node is empty after the `deleteCompositionText` event, and this prevents that
- Don't `setSelection` while composing, which will cancel compositions in Safari