### PR TITLE
Use useEditorStateSelector to only re-render relevant NodeView at composition boundaries

### DIFF
--- a/.yarn/versions/dbabbfa1.yml
+++ b/.yarn/versions/dbabbfa1.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/ProseMirror.tsx
+++ b/src/components/ProseMirror.tsx
@@ -4,7 +4,6 @@ import {
   ChildDescriptionsContext,
   ChildDescriptionsContextValue,
 } from "../contexts/ChildDescriptionsContext.js";
-import { CompositionContext } from "../contexts/CompositionContext.js";
 import { EditorContext } from "../contexts/EditorContext.js";
 import { EditorStateContext } from "../contexts/EditorStateContext.js";
 import {
@@ -14,7 +13,6 @@ import {
 import { computeDocDeco } from "../decorations/computeDocDeco.js";
 import { viewDecorations } from "../decorations/viewDecorations.js";
 import { UseEditorOptions, useEditor } from "../hooks/useEditor.js";
-import { reactKeysPluginKey } from "../plugins/reactKeys.js";
 
 import {
   EditorStateSelectorsProvider,
@@ -78,15 +76,6 @@ function ProseMirrorInner({
     [node, decorations, innerDecorations]
   );
 
-  const freezeFrom = reactKeysPluginKey.getState(state)?.freezeFrom ?? null;
-
-  const compositionContextValue = useMemo(
-    () => ({
-      freezeFrom,
-    }),
-    [freezeFrom]
-  );
-
   return (
     <EditorContext.Provider value={editor}>
       <EditorStateContext.Provider value={state}>
@@ -95,11 +84,9 @@ function ProseMirrorInner({
             <ChildDescriptionsContext.Provider
               value={rootChildDescriptionsContextValue}
             >
-              <CompositionContext.Provider value={compositionContextValue}>
-                <DocNodeViewContext.Provider value={docNodeViewContextValue}>
-                  {children}
-                </DocNodeViewContext.Provider>
-              </CompositionContext.Provider>
+              <DocNodeViewContext.Provider value={docNodeViewContextValue}>
+                {children}
+              </DocNodeViewContext.Provider>
             </ChildDescriptionsContext.Provider>
           </NodeViewContext.Provider>
         </EditorStateSelectorsProvider>

--- a/src/components/nodes/NodeView.tsx
+++ b/src/components/nodes/NodeView.tsx
@@ -15,8 +15,9 @@ import React, {
   useRef,
 } from "react";
 
-import { CompositionContext } from "../../contexts/CompositionContext.js";
 import { NodeViewContext } from "../../contexts/NodeViewContext.js";
+import { useEditorStateSelector } from "../../hooks/useEditorStateSelector.js";
+import { reactKeysPluginKey } from "../../plugins/reactKeys.js";
 
 import { DefaultNodeView } from "./DefaultNodeView.js";
 import { NodeViewComponentProps } from "./NodeViewComponentProps.js";
@@ -36,7 +37,9 @@ export const NodeView = memo(function NodeView({
   ...props
 }: Props) {
   const renderRef = useRef<JSX.Element | null>(null);
-  const { freezeFrom } = useContext(CompositionContext);
+  const frozen = useEditorStateSelector(
+    (state) => reactKeysPluginKey.getState(state)?.freezeFrom === props.getPos()
+  );
   const { components, constructors } = useContext(NodeViewContext);
 
   const committedFrozenRef = useRef(false);
@@ -62,12 +65,6 @@ export const NodeView = memo(function NodeView({
       };
     }
   }, [constructor, component]);
-
-  // It's not generally safe to access getPos during render, because the
-  // component may not re-render when its return value would change. Here it's
-  // safe because we only use it to _suppress_ commits that would otherwise
-  // have happened.
-  const frozen = props.getPos() === freezeFrom;
 
   // Protect content while frozen, and also through the single render where we
   // leave the frozen state: `committedFrozenRef` still reflects the previous

--- a/src/contexts/CompositionContext.ts
+++ b/src/contexts/CompositionContext.ts
@@ -1,9 +1,0 @@
-import { createContext } from "react";
-
-export interface CompositionContextValue {
-  freezeFrom: number | null;
-}
-
-export const CompositionContext = createContext<CompositionContextValue>({
-  freezeFrom: null,
-});


### PR DESCRIPTION
Using the CompositionContext meant that every single NodeView at every level of the document re-rendered every time a composition started and stopped.

Using the new useEditorStateSelector, we can instead only re-render the node that should actually become frozen/unfrozen!