### PR TITLE
fix: pass getServerSnapshot param to useSyncExternalStore

### DIFF
--- a/.yarn/versions/728425ba.yml
+++ b/.yarn/versions/728425ba.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useEditorStateSelector.ts
+++ b/src/hooks/useEditorStateSelector.ts
@@ -19,7 +19,6 @@ export function useEditorStateSelector<Result>(
   const selectorRef = useRef(selector);
   selectorRef.current = selector;
 
-  return useSyncExternalStore(store.subscribe, () =>
-    selectorRef.current(store.getState())
-  );
+  const getSnapshot = () => selectorRef.current(store.getState());
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
 }


### PR DESCRIPTION
We have to pass a getServerSnapshot to useSyncExternalStore, otherwise it'll throw an error during server render