### PR TITLE
Iter deco fix

### DIFF
--- a/.yarn/versions/007ad20d.yml
+++ b/.yarn/versions/007ad20d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/decorations/iterDeco.ts
+++ b/src/decorations/iterDeco.ts
@@ -134,6 +134,9 @@ export function iterDeco(
         end = cutAt;
         index = -1;
       }
+    } else {
+      while (decoIndex < locals.length && locals[decoIndex]!.to < end)
+        decoIndex++;
     }
 
     const outerDeco =


### PR DESCRIPTION
Pull in [this](https://code.haverbeke.berlin/prosemirror/prosemirror-view/commit/2fa9b02aa183881318e519af66e7ffd6ea9b6b96) iterDeco fix that was added - note that the second `<=` was later changed to just `<`, see current state [here](https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/commit/b65a9431aaeb76c86e550bb605014d77ab12abb6/src/viewdesc.ts#L1522).