### PR TITLE
Add content DOM to React node view specs

### DIFF
--- a/.yarn/versions/916cb5f4.yml
+++ b/.yarn/versions/916cb5f4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/marks/ReactMarkView.tsx
+++ b/src/components/marks/ReactMarkView.tsx
@@ -62,6 +62,7 @@ export const ReactMarkView = memo(function ReactMarkView({
     () => contentDOMRef.current ?? ref.current,
     () => ({
       dom: ref.current as DOMNode,
+      contentDOM: contentDOMRef.current ?? ref.current,
       ignoreMutation(mutation) {
         const ignoreMutation = ignoreMutationRef.current;
         if (ignoreMutation) {

--- a/src/components/nodes/ReactNodeView.tsx
+++ b/src/components/nodes/ReactNodeView.tsx
@@ -107,6 +107,7 @@ export const ReactNodeView = memo(function ReactNodeView({
 
       return {
         dom: (nodeDOMRef.current ?? domRef.current) as DOMNode,
+        contentDOM: contentDOMRef.current,
         update() {
           return true;
         },


### PR DESCRIPTION
Since we're now passing the node view spec through to useStopEvent and useIgnoreMutation as `this`, we need to make sure that contentDOM is populated correctly