### PR TITLE
Also force selection flush if doc slice has changed

### DIFF
--- a/.yarn/versions/38ad4e2b.yml
+++ b/.yarn/versions/38ad4e2b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -294,12 +294,23 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     this.docView.markDirty(-1, -1);
 
     const nextSelection = this.nextProps.state.selection;
-    const currentSelection = this.prevState.selection;
+    const prevSelection = this.prevState.selection;
 
-    const selectionChanged = !nextSelection.eq(currentSelection);
-    if (selectionChanged) {
-      super.update(this.nextProps);
-    } else {
+    const selectionChanged = !nextSelection.eq(prevSelection);
+
+    const needsSelectionUpdate =
+      selectionChanged ||
+      // If the doc within the selection has changed, then the DOM has likely changed.
+      // In this case, we need to force a re-sync of the selection, because the browser
+      // will have probably collapsed the selection to work around the new DOM, which
+      // no longer matches the previous selection.
+      !this.prevState.doc
+        .slice(prevSelection.from, prevSelection.to)
+        .eq(
+          this.nextProps.state.doc.slice(prevSelection.from, prevSelection.to)
+        );
+
+    if (!needsSelectionUpdate) {
       // If the selection hasn't changed between renders, force
       // prosemirror-view to skip the selectionToDOM call. If a render happens after a DOM
       // selection change but before the "selectionchange" event fired, calling
@@ -309,9 +320,11 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
         allowDefault: false,
         delayedSelectionSync: false,
       };
+    }
 
-      super.update(this.nextProps);
+    super.update(this.nextProps);
 
+    if (!needsSelectionUpdate) {
       this.input.mouseDown = null;
     }
 


### PR DESCRIPTION
This is a workaround for a bug: sometimes, when a non-empty selection is changed (e.g. via changing the marks on the selection), the user ends up with a collapsed DOM selection after the change, even though the PM selection is still the non-empty range selection.

This was happening because we were skipping the selection update, because the selection hadn't changed, but the DOM selection _had_ changed, because it was pointing at DOM nodes and offsets that either no longer existed or were no longer valid, after the corresponding DOM change.

This adds a secondary check: if the selection hasn't changed, but the slice of the doc _within_ the selection has changed, force a selection update.

This doesn't account for the other ways that the DOM can change:

- Decorations
- React node view updates

I think we should release this for now but keep thinking about whether this is the right way to address the underlying issue!