### PR TITLE
Drop Tiptap peer dep range to 3.0.0

### DIFF
--- a/.yarn/versions/b81db8ad.yml
+++ b/.yarn/versions/b81db8ad.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/package.json
+++ b/package.json
@@ -132,9 +132,9 @@
     "prosemirror-view": "1.41.7"
   },
   "peerDependencies": {
-    "@tiptap/core": "^3.15.3",
-    "@tiptap/pm": "^3.15.3",
-    "@tiptap/react": "^3.15.3",
+    "@tiptap/core": "^3.0.0",
+    "@tiptap/pm": "^3.0.0",
+    "@tiptap/react": "^3.0.0",
     "prosemirror-model": "^1.0.0",
     "prosemirror-state": "^1.0.0",
     "prosemirror-view": "1.41.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,9 +1706,9 @@ __metadata:
     webdriver: "npm:^9.18.0"
     webdriverio: "npm:^9.18.1"
   peerDependencies:
-    "@tiptap/core": ^3.15.3
-    "@tiptap/pm": ^3.15.3
-    "@tiptap/react": ^3.15.3
+    "@tiptap/core": ^3.0.0
+    "@tiptap/pm": ^3.0.0
+    "@tiptap/react": ^3.0.0
     prosemirror-model: ^1.0.0
     prosemirror-state: ^1.0.0
     prosemirror-view: 1.41.7


### PR DESCRIPTION
These were, I think, unintentionally bumped when I added `@tiptap/pm` months ago. I don't think there's any reason for them to be stuck on a specific minor/patch version.