### PR TITLE
Revert selection sync fix attempt

### DIFF
--- a/.yarn/versions/a35698fd.yml
+++ b/.yarn/versions/a35698fd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/ReactEditorView.ts
+++ b/src/ReactEditorView.ts
@@ -293,40 +293,7 @@ export class ReactEditorView extends EditorView implements AbstractEditorView {
     // node view selection callbacks.
     this.docView.markDirty(-1, -1);
 
-    const nextSelection = this.nextProps.state.selection;
-    const prevSelection = this.prevState.selection;
-
-    const selectionChanged = !nextSelection.eq(prevSelection);
-
-    const needsSelectionUpdate =
-      selectionChanged ||
-      // If the doc within the selection has changed, then the DOM has likely changed.
-      // In this case, we need to force a re-sync of the selection, because the browser
-      // will have probably collapsed the selection to work around the new DOM, which
-      // no longer matches the previous selection.
-      !this.prevState.doc
-        .slice(prevSelection.from, prevSelection.to)
-        .eq(
-          this.nextProps.state.doc.slice(prevSelection.from, prevSelection.to)
-        );
-
-    if (!needsSelectionUpdate) {
-      // If the selection hasn't changed between renders, force
-      // prosemirror-view to skip the selectionToDOM call. If a render happens after a DOM
-      // selection change but before the "selectionchange" event fired, calling
-      // selectionToDOM will cause the selection to be reset to its previous position.
-      this.domObserver.setCurSelection();
-      this.input.mouseDown = {
-        allowDefault: false,
-        delayedSelectionSync: false,
-      };
-    }
-
     super.update(this.nextProps);
-
-    if (!needsSelectionUpdate) {
-      this.input.mouseDown = null;
-    }
 
     // Store the new previous state.
     this.prevState = this.state;


### PR DESCRIPTION
Because browsers don't dispatch `selectionchange` events synchronously when the DOM selection changes, we can end up running side effects after the DOM selection has changed but before the `selectionchange` that notifies us has happened. Because `commitPendingEffects` syncs the DOM selection to the prosemirror selection, this has the effect of "reverting" a selection change.

The initial fix attempt tried to only call `selectionToDOM` if the prosemirror selection changed, but this doesn't account for when the DOM has changed/been replaced but the prosemirror selection hasn't changed.