### PR TITLE
Restore flushSync in an immediate task to fix y-cursor

### DIFF
--- a/.yarn/versions/d9c0b392.yml
+++ b/.yarn/versions/d9c0b392.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -132,7 +132,38 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
     if (view instanceof ReactEditorView && !view.isDestroyed) {
       flushSyncRef.current = false;
       view.commitPendingEffects();
-      flushSyncRef.current = true;
+      // This is guarding against a very specific pathological
+      // behavior in a ProseMirror plugin, which is unfortunately
+      // implemented in the very popular y-cursor plugin.
+      //
+      // If a plugin dispatches a transaction in an immediately
+      // scheduled task (i.e. setTimeout(..., 0)) during the update
+      // lifecycle method, AND the user has changed the selection
+      // while this render cycle was being committed, that
+      // scheduled task will execute _exactly_ between when the
+      // DOM selection updates and when the selectionchange
+      // event is fired. This will cause commitPendingEffects
+      // to override the pending selection change with the
+      // previous state.
+      //
+      // However, this is only an issue because we wrap all dispatches
+      // in a flushSync call, unless they run synchronously during
+      // a useEditorEffect or commitPendingEffects. If the
+      // scheduled dispatch is not flushSync'd, then
+      // commitPendingEffects will run _after_ the selectionchange
+      // event, and everything is fine.
+      //
+      // So we schedule the re-enabling of flushSync in our
+      // own immediate task. Since it's scheduled _after_
+      // commitPendingEffects runs, it's guaranteed to execute
+      // after any immediate tasks scheduled during
+      // commitPendingEffects. This means that we avoid the
+      // possibility of an immediately scheduled task from
+      // an update method running between the DOM selection update
+      // and the selectionchange update.
+      setTimeout(() => {
+        flushSyncRef.current = true;
+      }, 0);
     }
   });
 

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -42,9 +42,10 @@ export function useEditorEffect(
   useLayoutGroupEffect(
     () => {
       if (view instanceof ReactEditorView) {
+        const originalFlushSync = flushSyncRef.current;
         flushSyncRef.current = false;
         const result = effect(view);
-        flushSyncRef.current = true;
+        flushSyncRef.current = originalFlushSync;
         return result;
       }
     },


### PR DESCRIPTION
Alternative fix for #224!

```ts
      // This is guarding against a very specific pathological
      // behavior in a ProseMirror plugin, which is unfortunately
      // implemented in the very popular y-cursor plugin.
      //
      // If a plugin dispatches a transaction in an immediately
      // scheduled task (i.e. setTimeout(..., 0)) during the update
      // lifecycle method, AND the user has changed the selection
      // while this render cycle was being committed, that
      // scheduled task will execute _exactly_ between when the
      // DOM selection updates and when the selectionchange
      // event is fired. This will cause commitPendingEffects
      // to override the pending selection change with the
      // previous state.
      //
      // However, this is only an issue because we wrap all dispatches
      // in a flushSync call, unless they run synchronously during
      // a useEditorEffect or commitPendingEffects. If the
      // scheduled dispatch is not flushSync'd, then
      // commitPendingEffects will run _after_ the selectionchange
      // event, and everything is fine.
      //
      // So we schedule the re-enabling of flushSync in our
      // own immediate task. Since it's scheduled _after_
      // commitPendingEffects runs, it's guaranteed to execute
      // after any immediate tasks scheduled during
      // commitPendingEffects. This means that we avoid the
      // possibility of an immediately scheduled task from
      // an update method running between the DOM selection update
      // and the selectionchange update.
```

I'm pretty sure that a consequence of this is that it's possible for a microtask (e.g. a Promise resolution) to now run without flushSync that previously would have run with flushSync. My hope is that there aren't any Promise resolutions that rely on the flushSync behavior (that is, that attempt to synchronously read the DOM after dispatching, expecting the change to have been committed) in the wild. It seems worth it to fix a really painful selection reversion bug for all y-cursor users (or at least all y-cursor users with slow document renders).

Edit: I just checked, I don't think that this is an issue with modern y-cursor, only with older versions that relied heavily on setTimeouts.