### PR TITLE
Allow consumers to update DOM asynchronously for certain transactions

### DIFF
--- a/.yarn/versions/a8b09489.yml
+++ b/.yarn/versions/a8b09489.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -71,8 +71,8 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
 
   const dispatchTransaction = useCallback(
     function dispatchTransaction(this: EditorView, tr: Transaction) {
-      const skipFlushSync = tr.getMeta("skipFlushSync");
-      if (flushSyncRef.current && !skipFlushSync) {
+      const async = tr.getMeta("async");
+      if (flushSyncRef.current && !async) {
         flushSync(() => {
           if (!options.state) {
             setState((s) => s.apply(tr));

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -71,7 +71,8 @@ export function useEditor<T extends HTMLElement = HTMLElement>(
 
   const dispatchTransaction = useCallback(
     function dispatchTransaction(this: EditorView, tr: Transaction) {
-      if (flushSyncRef.current) {
+      const skipFlushSync = tr.getMeta("skipFlushSync");
+      if (flushSyncRef.current && !skipFlushSync) {
         flushSync(() => {
           if (!options.state) {
             setState((s) => s.apply(tr));


### PR DESCRIPTION
Provide a mechanism for consumers to skip flushSync on certain transactions - if a transaction has `async` set to true in its meta, do not `flushSync` in `dispatchTransaction`