### PR TITLE
Register the separator hack view desc once it renders

### DIFF
--- a/.yarn/versions/98d95e70.yml
+++ b/.yarn/versions/98d95e70.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/SeparatorHackView.tsx
+++ b/src/components/SeparatorHackView.tsx
@@ -35,10 +35,12 @@ export function SeparatorHackView({ getPos }: Props) {
     );
     const lastSibling = nonHackSiblings[nonHackSiblings.length - 1];
     if (
+      !shouldRender &&
       (browser.safari || browser.chrome) &&
       (lastSibling?.dom as HTMLElement)?.contentEditable == "false"
     ) {
       setShouldRender(true);
+      return;
     }
 
     if (!ref.current) return;

--- a/src/components/SeparatorHackView.tsx
+++ b/src/components/SeparatorHackView.tsx
@@ -39,7 +39,6 @@ export function SeparatorHackView({ getPos }: Props) {
       (lastSibling?.dom as HTMLElement)?.contentEditable == "false"
     ) {
       setShouldRender(true);
-      return;
     }
 
     if (!ref.current) return;


### PR DESCRIPTION
This is a PR that handles the issue that comes up from https://github.com/goranmoomin/react-prosemirror-separator-viewdesc-repro. The minimal repro repository, while generated by an LLM, demonstrates the exact issue that we had. We have been using this patch for months at https://github.com/fastrepl, so I believe that this is a good fix.

<img width="198" height="139" alt="CleanShot 2026-08-19 at 16 27 27@2x" src="https://github.com/user-attachments/assets/b8e2d0c2-d750-4c44-ab64-0af9aaf4932a" />

When `@chip` in the document is an inline atom node view, the caret, when placed at the end of the line, does not move to the next line when pressed right arrow because the view desc for the separator hack view (placed after the caret) is not registered.