### PR TITLE
Handle node view desc ref churn

### DIFF
--- a/src/hooks/useMarkViewDescription.ts
+++ b/src/hooks/useMarkViewDescription.ts
@@ -30,6 +30,11 @@ export function useMarkViewDescription(
 
   const contentDOMRef = useRef<HTMLElement | null>(null);
 
+  // Tracks the mount layout effect's lifecycle, as in
+  // useNodeViewDescription: refUpdated must be inert between that
+  // effect's cleanup and its next run, and must still run after a
+  // callback ref churn, which a viewDescRef guard alone gets wrong.
+  const mountedRef = useRef(false);
   const viewDescRef = useRef<MarkViewDesc | undefined>();
   const childrenRef = useRef<ViewDesc[]>([]);
 
@@ -72,6 +77,17 @@ export function useMarkViewDescription(
     for (const child of children) {
       child.parent = viewDesc;
     }
+
+    // Register with the parent's children immediately, as the node view
+    // hook does. create() can run from a ref callback (refUpdated)
+    // without a following layout effect, and a live desc that is absent
+    // from its parent's children corrupts position mapping
+    // (posBeforeChild walks past the end of the array).
+    const siblings = siblingsRef.current;
+    if (!siblings.includes(viewDesc)) {
+      siblings.push(viewDesc);
+    }
+    siblings.sort(sortViewDescs);
 
     contentDOMRef.current = contentDOM;
 
@@ -121,18 +137,27 @@ export function useMarkViewDescription(
   });
 
   useClientLayoutEffect(() => {
+    mountedRef.current = true;
     viewDescRef.current = create();
     return () => {
+      mountedRef.current = false;
       destroy();
     };
   }, [create, destroy]);
 
+  // A null DOM on a ref detach pass while mounted is transient, as in
+  // useNodeViewDescription: the attach pass re-syncs the desc, and a
+  // real unmount destroys it in the layout effect cleanup.
+  const domDetached = useEffectEvent(() => getDOM() == null);
+
   const refUpdated = useCallback(() => {
+    if (!mountedRef.current) return;
+    if (domDetached()) return;
     if (!update()) {
       destroy();
       viewDescRef.current = create();
     }
-  }, [create, destroy, update]);
+  }, [create, destroy, domDetached, update]);
 
   useClientLayoutEffect(() => {
     if (!update()) {

--- a/src/hooks/useNodeViewDescription.ts
+++ b/src/hooks/useNodeViewDescription.ts
@@ -29,6 +29,19 @@ export function useNodeViewDescription(
   const { parentRef, siblingsRef } = useContext(ChildDescriptionsContext);
   const contentDOMRef = useRef<HTMLElement | null>(null);
 
+  // Tracks the mount layout effect's lifecycle. refUpdated must be inert
+  // between that effect's cleanup and its next run: React detaches and
+  // reattaches callback refs around a simulated remount (StrictMode,
+  // Activity), and in that window viewDescRef still points at the
+  // destroyed desc, so update() can misjudge it and register a
+  // replacement that the effect's unconditional create() then orphans in
+  // the parent's children, corrupting position mapping. Guarding on
+  // viewDescRef alone gets the other direction wrong: a ref reattach
+  // after callback ref churn (#276) finds it empty and never recreates
+  // the desc. While mounted, every destroy is immediately followed by a
+  // create, so viewDescRef only ever holds a live desc and update() can
+  // be trusted.
+  const mountedRef = useRef(false);
   const viewDescRef = useRef<NodeViewDesc | undefined>();
   const childrenRef = useRef<ViewDesc[]>([]);
 
@@ -139,19 +152,30 @@ export function useNodeViewDescription(
   });
 
   useClientLayoutEffect(() => {
+    mountedRef.current = true;
     viewDescRef.current = create();
     return () => {
+      mountedRef.current = false;
       destroy();
     };
   }, [create, destroy]);
 
+  // React detaches a replaced callback ref by calling it with null
+  // before attaching its successor, so while mounted a null DOM here is
+  // transient: the attach pass that follows re-syncs the desc, and a
+  // real unmount destroys it in the layout effect cleanup. Tearing the
+  // desc down on the detach pass would destroy and recreate it even
+  // though the DOM never changed.
+  const domDetached = useEffectEvent(() => getDOM() == null);
+
   const refUpdated = useCallback(() => {
-    if (!viewDescRef.current) return;
+    if (!mountedRef.current) return;
+    if (domDetached()) return;
     if (!update()) {
       destroy();
       viewDescRef.current = create();
     }
-  }, [create, destroy, update]);
+  }, [create, destroy, domDetached, update]);
 
   useClientLayoutEffect(() => {
     if (!update()) {


### PR DESCRIPTION
This PR fixes the issue from https://github.com/goranmoomin/react-prosemirror-node-ref-churn-repro as well as https://github.com/goranmoomin/react-prosemirror-mark-ref-churn-repro, the first repository also being a test case for #276.

https://github.com/user-attachments/assets/b81ee3fa-8911-4890-b5f4-52ab8efbec95

https://github.com/user-attachments/assets/8e81ee3c-28e7-47a1-94f0-4c78e798bdf9

Both are cases where the node view or the mark view uses a callback ref (I personally encountered them when using shadcn/ui popover inside a node view). This is also a patch that we've been using for quite some time, but renamed a few variables and cleaned up.

The issue is that `getDOM()` can be null when a callback ref is used due to the cleanup call of the callback, and as soon as that happens, the current code just loses the view descriptor altogether. This fix includes some logic to make sure that we don't churn the view desc if `getDOM()` dips to null and then gains the dom element back. Unfortunately, this means that if the ref gets null permanently (i.e. the node/mark view renders null) then we can't cleanup the view desc, but I think that's a non-problem for now (since that's just not a valid case) as well as we would be able to clean up the descriptor when it does actually render something again or if the component unmounts. (At least that was my personal, non-LLM assessment.)

The same issue exists for the mark view, TBH I don't remember 100% on what the issue was for the mark view in our application, but we did have issues around the losing the descriptor as well, the repro case is a bug and we have been holding this patch for like at least a month or two, so pushing it together in the PR as well.