### PR TITLE
Handle unstable refs

### DIFF
--- a/.yarn/versions/9c63cd1e.yml
+++ b/.yarn/versions/9c63cd1e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-prosemirror": patch

--- a/src/components/__tests__/ProseMirror.node-view.test.tsx
+++ b/src/components/__tests__/ProseMirror.node-view.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { Plugin } from "prosemirror-state";
 import { blockquote, br, doc, p, strong } from "prosemirror-test-builder";
 import {
@@ -8,12 +8,15 @@ import {
   DecorationSet,
   ViewMutationRecord,
 } from "prosemirror-view";
-import React, { forwardRef, useEffect } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 
 import { useEditorState } from "../../hooks/useEditorState.js";
 import { useStopEvent } from "../../hooks/useStopEvent.js";
 import { useMergedDOMRefs } from "../../refs.js";
-import { tempEditor } from "../../testing/editorViewTestHelpers.js";
+import {
+  findTextNode,
+  tempEditor,
+} from "../../testing/editorViewTestHelpers.js";
 import { MarkViewComponentProps } from "../marks/MarkViewComponentProps.js";
 import { NodeViewComponentProps } from "../nodes/NodeViewComponentProps.js";
 
@@ -132,6 +135,140 @@ describe("nodeViewComponents prop", () => {
     expect(para.textContent).toBe("afoo");
   });
 
+  it("does not re-render indefinitely when the node view uses an unstable ref callback", async () => {
+    let renders = 0;
+    const { view } = tempEditor({
+      doc: doc(p("foo")),
+      nodeViewComponents: {
+        paragraph: forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
+          function Paragraph({ children, nodeProps }, ref) {
+            renders++;
+            const contentDOMRef = nodeProps.contentDOMRef as (
+              el: HTMLElement | null
+            ) => void;
+            const setRef = (el: HTMLParagraphElement | null) => {
+              if (ref) {
+                if (typeof ref === "function") ref(el);
+                else ref.current = el;
+              }
+              contentDOMRef(el);
+            };
+            return <p ref={setRef}>{children}</p>;
+          }
+        ),
+      },
+    });
+
+    const para = view.dom.querySelector("p")!;
+    const base = renders;
+    act(() => {
+      view.dispatch(view.state.tr.insertText("a"));
+    });
+
+    expect(renders).toBe(base + 1);
+    expect(view.dom.querySelector("p")).toBe(para);
+    expect(para.textContent).toBe("afoo");
+  });
+
+  it("keeps its view desc when an unstable ref callback churns on re-render", async () => {
+    let renders = 0;
+    let bump: () => void;
+    const { view } = tempEditor({
+      doc: doc(p("hello")),
+      nodeViewComponents: {
+        paragraph: forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
+          function Paragraph({ children }, ref) {
+            renders++;
+            const [version, setVersion] = useState(0);
+            bump = () => setVersion((v) => v + 1);
+            const setRef = (el: HTMLParagraphElement | null) => {
+              if (ref) {
+                if (typeof ref === "function") ref(el);
+                else ref.current = el;
+              }
+            };
+            return (
+              <p ref={setRef} data-version={version}>
+                {children}
+              </p>
+            );
+          }
+        ),
+      },
+    });
+
+    const para = view.dom.querySelector("p")!;
+    const text = findTextNode(para, "hello");
+    const desc = para.pmViewDesc;
+    expect(desc).toBeTruthy();
+    const base = renders;
+    act(() => {
+      bump();
+    });
+
+    expect(renders).toBe(base + 1);
+    expect(para.pmViewDesc).toBe(desc);
+    for (let i = 0; i <= 5; i++) {
+      expect(view.posAtDOM(text, i)).toBe(1 + i);
+    }
+  });
+
+  it("recreates its view desc when the contentDOM element is removed and restored", async () => {
+    let renders = 0;
+    let toggle: (show: boolean) => void;
+    const { view } = tempEditor({
+      doc: doc(p("foo")),
+      nodeViewComponents: {
+        paragraph: forwardRef<HTMLParagraphElement, NodeViewComponentProps>(
+          function Paragraph({ children, nodeProps, ...props }, ref) {
+            renders++;
+            const [showContentDOM, setShowContentDOM] = useState(true);
+            toggle = setShowContentDOM;
+            return (
+              <p {...props} ref={ref}>
+                {showContentDOM ? (
+                  <span ref={nodeProps.contentDOMRef}>{children}</span>
+                ) : (
+                  children
+                )}
+              </p>
+            );
+          }
+        ),
+      },
+    });
+
+    const para = view.dom.querySelector("p")!;
+    const desc = para.pmViewDesc;
+    expect(desc).toBeTruthy();
+    expect(para.getAttribute("contenteditable")).toBeNull();
+    const base = renders;
+
+    await act(async () => {
+      toggle(false);
+    });
+    expect(renders).toBe(base + 2);
+    expect(para.getAttribute("contenteditable")).toBe("false");
+    expect(para.pmViewDesc).toBeTruthy();
+    expect(para.pmViewDesc).not.toBe(desc);
+    const text = findTextNode(para, "foo");
+    for (let i = 0; i <= 3; i++) {
+      expect(view.posAtDOM(text, i)).toBe(1 + i);
+    }
+
+    act(() => {
+      toggle(true);
+    });
+
+    expect(renders).toBe(base + 4);
+    expect(para.getAttribute("contenteditable")).toBeNull();
+    expect(para.pmViewDesc).toBeTruthy();
+    const restoredText = findTextNode(para, "foo");
+    for (let i = 0; i <= 3; i++) {
+      expect(view.posAtDOM(restoredText, i)).toBe(1 + i);
+    }
+  });
+
   it("has its destroy method called", async () => {
     let destroyed = 0;
     const { view } = tempEditor({
@@ -152,6 +289,37 @@ describe("nodeViewComponents prop", () => {
       },
     });
     view.dispatch(view.state.tr.delete(3, 5));
+    expect(destroyed).toBe(1);
+  });
+
+  it("destroys its node view exactly once when the node is removed", async () => {
+    let destroyed = 0;
+    const { view } = tempEditor({
+      doc: doc(p("foo", br())),
+      nodeViewComponents: {
+        hard_break: forwardRef<HTMLBRElement, NodeViewComponentProps>(
+          function BR(_props, ref) {
+            useEffect(() => {
+              return () => {
+                destroyed++;
+              };
+            }, []);
+            const setRef = (el: HTMLBRElement | null) => {
+              if (ref) {
+                if (typeof ref === "function") ref(el);
+                else ref.current = el;
+              }
+            };
+            return <br ref={setRef} />;
+          }
+        ),
+      },
+    });
+
+    act(() => {
+      view.dispatch(view.state.tr.delete(3, 5));
+    });
+
     expect(destroyed).toBe(1);
   });
 
@@ -352,6 +520,50 @@ describe("markViewComponents prop", () => {
     view.dispatch(view.state.tr.insertText("a"));
     expect(view.dom.querySelector("p")).toBe(para);
     expect(para.textContent).toBe("afoo");
+  });
+
+  it("keeps its view desc when an unstable ref callback churns on re-render", async () => {
+    let renders = 0;
+    let bump: () => void;
+    const { view } = tempEditor({
+      doc: doc(p(strong("hello"))),
+      markViewComponents: {
+        strong: forwardRef<HTMLElement, MarkViewComponentProps>(function Strong(
+          { children },
+          ref
+        ) {
+          renders++;
+          const [version, setVersion] = useState(0);
+          bump = () => setVersion((v) => v + 1);
+          const setRef = (el: HTMLElement | null) => {
+            if (ref) {
+              if (typeof ref === "function") ref(el);
+              else ref.current = el;
+            }
+          };
+          return (
+            <strong ref={setRef} data-version={version}>
+              {children}
+            </strong>
+          );
+        }),
+      },
+    });
+
+    const strongEl = view.dom.querySelector("strong")!;
+    const text = findTextNode(strongEl, "hello");
+    const desc = strongEl.pmViewDesc;
+    expect(desc).toBeTruthy();
+    const base = renders;
+    act(() => {
+      bump();
+    });
+
+    expect(renders).toBe(base + 1);
+    expect(strongEl.pmViewDesc).toBe(desc);
+    for (let i = 0; i <= 5; i++) {
+      expect(view.posAtDOM(text, i)).toBe(1 + i);
+    }
   });
 
   it("has its destroy method called", async () => {

--- a/src/components/marks/ReactMarkView.tsx
+++ b/src/components/marks/ReactMarkView.tsx
@@ -14,6 +14,7 @@ import {
   IgnoreMutationContext,
 } from "../../contexts/IgnoreMutationContext.js";
 import { useMarkViewDescription } from "../../hooks/useMarkViewDescription.js";
+import { useSetDom } from "../../hooks/useSetDom.js";
 
 import { MarkViewComponentProps } from "./MarkViewComponentProps.js";
 
@@ -74,21 +75,9 @@ export const ReactMarkView = memo(function ReactMarkView({
     markViewDescProps
   );
 
-  const setDOM = useCallback(
-    (el: HTMLElement | null) => {
-      ref.current = el;
-      refUpdated();
-    },
-    [refUpdated]
-  );
+  const setDOM = useSetDom(ref, refUpdated);
 
-  const setContentDOM = useCallback(
-    (el: HTMLElement | null) => {
-      contentDOMRef.current = el;
-      refUpdated();
-    },
-    [refUpdated]
-  );
+  const setContentDOM = useSetDom(contentDOMRef, refUpdated);
 
   const markProps = useMemo(
     () => ({

--- a/src/components/nodes/ReactNodeView.tsx
+++ b/src/components/nodes/ReactNodeView.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../contexts/StopEventContext.js";
 import { useForceUpdate } from "../../hooks/useForceUpdate.js";
 import { useNodeViewDescription } from "../../hooks/useNodeViewDescription.js";
+import { useSetDom } from "../../hooks/useSetDom.js";
 import { ChildNodeViews, wrapInDeco } from "../ChildNodeViews.js";
 import { NodeViewComponentProps } from "../nodes/NodeViewComponentProps.js";
 
@@ -98,7 +99,7 @@ export const ReactNodeView = memo(function ReactNodeView({
     [getPos, innerDeco, node, outerDeco]
   );
 
-  const { childContextValue, refUpdated } = useNodeViewDescription(
+  const { childContextValue, refUpdated, isMounted } = useNodeViewDescription(
     () => domRef.current,
     () => contentDOMRef.current,
     () => {
@@ -148,40 +149,15 @@ export const ReactNodeView = memo(function ReactNodeView({
     nodeViewDescProps
   );
 
-  const setDOM = useCallback(
-    (el: HTMLElement | null) => {
-      domRef.current = el;
-      refUpdated();
-    },
-    [refUpdated]
-  );
+  const setDOM = useSetDom(domRef, refUpdated, isMounted, forceUpdate);
 
-  const setNodeDOM = useCallback(
-    (el: HTMLElement | null) => {
-      if (!!nodeDOMRef.current !== !!el) {
-        // Force a re-render if the existence of nodeDOM
-        // is changing, since we use its existince to set
-        // some props
-        forceUpdate();
-      }
-      nodeDOMRef.current = el;
-      refUpdated();
-    },
-    [forceUpdate, refUpdated]
-  );
+  const setNodeDOM = useSetDom(nodeDOMRef, refUpdated, isMounted, forceUpdate);
 
-  const setContentDOM = useCallback(
-    (el: HTMLElement | null) => {
-      if (!!contentDOMRef.current !== !!el) {
-        // Force a re-render if the existence of contentDOM
-        // is changing, since we use its existince to set
-        // some props
-        forceUpdate();
-      }
-      contentDOMRef.current = el;
-      refUpdated();
-    },
-    [forceUpdate, refUpdated]
+  const setContentDOM = useSetDom(
+    contentDOMRef,
+    refUpdated,
+    isMounted,
+    forceUpdate
   );
 
   const nodeProps = useMemo(

--- a/src/hooks/useMarkViewDescription.ts
+++ b/src/hooks/useMarkViewDescription.ts
@@ -25,6 +25,7 @@ export function useMarkViewDescription(
   constructor: MarkViewConstructor,
   props: Props
 ) {
+  const mountedRef = useRef(false);
   const { view } = useContext(EditorContext);
   const { parentRef, siblingsRef } = useContext(ChildDescriptionsContext);
 
@@ -108,6 +109,7 @@ export function useMarkViewDescription(
       return;
     }
 
+    viewDescRef.current = undefined;
     viewDesc.destroy();
 
     const siblings = siblingsRef.current;
@@ -121,13 +123,16 @@ export function useMarkViewDescription(
   });
 
   useClientLayoutEffect(() => {
+    mountedRef.current = true;
     viewDescRef.current = create();
     return () => {
+      mountedRef.current = false;
       destroy();
     };
   }, [create, destroy]);
 
   const refUpdated = useCallback(() => {
+    if (!mountedRef.current) return;
     if (!update()) {
       destroy();
       viewDescRef.current = create();

--- a/src/hooks/useNodeViewDescription.ts
+++ b/src/hooks/useNodeViewDescription.ts
@@ -25,6 +25,7 @@ export function useNodeViewDescription(
   constructor: NodeViewConstructor,
   props: Props
 ) {
+  const mountedRef = useRef(false);
   const { view } = useContext(EditorContext);
   const { parentRef, siblingsRef } = useContext(ChildDescriptionsContext);
   const contentDOMRef = useRef<HTMLElement | null>(null);
@@ -126,6 +127,7 @@ export function useNodeViewDescription(
       return;
     }
 
+    viewDescRef.current = undefined;
     viewDesc.destroy();
 
     const siblings = siblingsRef.current;
@@ -139,14 +141,16 @@ export function useNodeViewDescription(
   });
 
   useClientLayoutEffect(() => {
+    mountedRef.current = true;
     viewDescRef.current = create();
     return () => {
+      mountedRef.current = false;
       destroy();
     };
   }, [create, destroy]);
 
   const refUpdated = useCallback(() => {
-    if (!viewDescRef.current) return;
+    if (!mountedRef.current) return;
     if (!update()) {
       destroy();
       viewDescRef.current = create();
@@ -208,9 +212,12 @@ export function useNodeViewDescription(
     []
   );
 
+  const isMounted = useCallback(() => mountedRef.current, []);
+
   return {
     childContextValue,
     contentDOM: contentDOMRef.current,
     refUpdated,
+    isMounted,
   };
 }

--- a/src/hooks/useSetDom.tsx
+++ b/src/hooks/useSetDom.tsx
@@ -1,0 +1,55 @@
+import { MutableRefObject, useCallback, useRef } from "react";
+
+export function useSetDom(
+  domRef: MutableRefObject<HTMLElement | null>,
+  refUpdated: () => void,
+  isMounted?: () => boolean,
+  forceUpdate?: () => void
+) {
+  const pendingRef = useRef(false);
+
+  return useCallback(
+    (el: HTMLElement | null) => {
+      if (el !== null) {
+        pendingRef.current = false;
+
+        const changed = domRef.current !== el;
+        domRef.current = el;
+        if (changed) forceUpdate?.();
+        refUpdated();
+        return;
+      }
+
+      if (pendingRef.current) return;
+      pendingRef.current = true;
+
+      // React calls old ref callbacks with
+      // null before synchronously calling
+      // new ref callbacks with the existing
+      // element ref. We don't have any
+      // way to distinguish a call with null
+      // because the downstream callback is
+      // unstable and being replaced during render
+      // from a call with null because the referenced
+      // element has been unmounted.
+      //
+      // Since the ref callback calls are synchronous,
+      // we can queue a microtask and check
+      // whether the ref is still null at
+      // the end of this event loop task. If it
+      // is, we actually unmounted. If it's not,
+      // we already handled it in the synchronous
+      // branch above, so we just bail.
+      queueMicrotask(() => {
+        if (!pendingRef.current) return;
+        pendingRef.current = false;
+        if (domRef.current !== null) {
+          domRef.current = null;
+          if (isMounted?.()) forceUpdate?.();
+        }
+        refUpdated();
+      });
+    },
+    [domRef, forceUpdate, isMounted, refUpdated]
+  );
+}


### PR DESCRIPTION
Fixes #276.

There were a few subtle issues in here that needed to be resolved.

1. #276: unstable callback refs on the DOM element would result in lost view descriptions, which break the view's DOM methods until the node is modified and the ReactNodeView component rerenders
2. Unstable callback refs on the nodeDOM or contentDOM would result in infinite loops
3. A suspended node view could never get a view description, because it didn't have one after the first `create()` call

All three are fixed by:

1. A mounted ref in the useNodeViewDescription/useMarkViewDescription hooks. We check this instead of the existence of a viewDesc to bail out of the refUpdated callback, which gets rid of the issue where we weren't recreating viewDesc's if they had been previously destroyed
2. A queueMicrotask hack in setDom/setNodeDom/setContentDom. Update non-null ref callback arguments immediately and trigger a re-render, but if we get _null_, then queue a microtask. If the ref is still null when the microtask runs, then the reffed element has actually been unmounted and we should update and rerender. If not, then bail, because this was churn due to an unstable ref (or simply an update from one element to another).